### PR TITLE
Improve FunctionLoader validations

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "google-protobuf": "^3.0.0",
     "grpc": "^1.6.0",
     "minimist": "^1.2.0",
-    "mock-require": "^2.0.2",
     "protobufjs": "6.7.0"
   },
   "devDependencies": {
@@ -14,6 +13,7 @@
     "@types/sinon": "^2.3.3",
     "chai": "^4.1.1",
     "mocha": "^3.5.0",
+    "mock-require": "^2.0.2",
     "node-pre-gyp": "0.6.37",
     "node-abi": "2.1.1",
     "rimraf": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "google-protobuf": "^3.0.0",
     "grpc": "^1.6.0",
     "minimist": "^1.2.0",
+    "mock-require": "^2.0.2",
     "protobufjs": "6.7.0"
   },
   "devDependencies": {

--- a/src/Converters.ts
+++ b/src/Converters.ts
@@ -1,5 +1,5 @@
 import { FunctionRpc as rpc } from '../protos/rpc';
-import { HttpRequest } from './http/request'
+import { HttpRequest } from './http/Request'
 export function fromRpcHttp(rpcHttp: rpc.RpcHttp$Properties) {
   let httpContext: HttpRequest = {
     method: <string>rpcHttp.method,

--- a/src/FunctionLoader.ts
+++ b/src/FunctionLoader.ts
@@ -19,6 +19,9 @@ export class FunctionLoader implements IFunctionLoader {
       let scriptFilePath = <string>metadata.scriptFile;
       let script = require(scriptFilePath);
       let userFunction = getEntryPoint(script, metadata.entryPoint);
+      if(!isFunction(userFunction)) {
+        throw "Unable to determine function. Make sure the function has been correctly exported";
+      }
       this._loadedFunctions[functionId] = {
           info: new FunctionInfo(metadata),
           func: userFunction
@@ -53,8 +56,8 @@ function getEntryPoint(f: any, entryPoint?: string): Function {
         }
     }
 
-    if (!isFunction(f)) {
-        throw "Unable to determine function entry point. If multiple functions are exported, " +
+    if (!f) {
+        throw (entryPoint ? `Unable to determine function entry point: ${entryPoint}. `: "Unable to determine function entry point. ") + "If multiple functions are exported, " +
             "you must indicate the entry point, either by naming it 'run' or 'index', or by naming it " +
             "explicitly via the 'entryPoint' metadata property.";
     }

--- a/src/FunctionLoader.ts
+++ b/src/FunctionLoader.ts
@@ -20,7 +20,7 @@ export class FunctionLoader implements IFunctionLoader {
       let script = require(scriptFilePath);
       let userFunction = getEntryPoint(script, metadata.entryPoint);
       if(!isFunction(userFunction)) {
-        throw "Unable to determine function. Make sure the function has been correctly exported";
+        throw "The resolved entry point is not a function and cannot be invoked by the functions runtime. Make sure the function has been correctly exported.";
       }
       this._loadedFunctions[functionId] = {
           info: new FunctionInfo(metadata),

--- a/test/FunctionLoaderTests.ts
+++ b/test/FunctionLoaderTests.ts
@@ -1,0 +1,55 @@
+import { WorkerChannel } from '../src/WorkerChannel';
+import { FunctionLoader } from '../src/FunctionLoader';
+import { TestEventStream } from './TestEventStream';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { FunctionRpc as rpc } from '../protos/rpc';
+import 'mocha';
+import mock = require('mock-require');
+
+describe('FunctionLoader', () => {
+  var channel: WorkerChannel;
+  var loader: FunctionLoader;
+  var require;
+  var functions;
+
+  beforeEach(() => {
+    loader = new FunctionLoader();
+  });
+
+  it ('throws unable to determine function entry point', () => {
+    mock('test', {});
+     expect(() => {
+        loader.load('functionId', <rpc.RpcFunctionMetadata$Properties> {
+            scriptFile: 'test'
+        })
+     }).to.throw("Unable to determine function entry point. If multiple functions are exported, you must indicate the entry point, either by naming it 'run' or 'index', or by naming it explicitly via the 'entryPoint' metadata property.");
+  });
+  
+  it ('throws unable to determine function entry point with entryPoint name', () => {
+    mock('test', { test: {} });
+    let entryPoint = 'wrongEntryPoint'
+    expect(() => {
+        loader.load('functionId', <rpc.RpcFunctionMetadata$Properties> {
+            scriptFile: 'test',
+            entryPoint: entryPoint
+        })
+    }).to.throw(`Unable to determine function entry point: ${entryPoint}. If multiple functions are exported, you must indicate the entry point, either by naming it 'run' or 'index', or by naming it explicitly via the 'entryPoint' metadata property.`);
+  });
+  
+  it ('throws unable to determine function', () => {
+    mock('test', { test: {} });
+    let entryPoint = 'test'
+    expect(() => {
+        loader.load('functionId', <rpc.RpcFunctionMetadata$Properties> {
+            scriptFile: 'test',
+            entryPoint: entryPoint
+        })
+    }).to.throw("Unable to determine function. Make sure the function has been correctly exported");
+  });
+  
+  afterEach(() => {
+    mock.stopAll()
+  });
+  
+})

--- a/test/FunctionLoaderTests.ts
+++ b/test/FunctionLoaderTests.ts
@@ -37,7 +37,7 @@ describe('FunctionLoader', () => {
     }).to.throw(`Unable to determine function entry point: ${entryPoint}. If multiple functions are exported, you must indicate the entry point, either by naming it 'run' or 'index', or by naming it explicitly via the 'entryPoint' metadata property.`);
   });
   
-  it ('throws unable to determine function', () => {
+  it ('throws the resolved entry point is not a function', () => {
     mock('test', { test: {} });
     let entryPoint = 'test'
     expect(() => {
@@ -45,7 +45,7 @@ describe('FunctionLoader', () => {
             scriptFile: 'test',
             entryPoint: entryPoint
         })
-    }).to.throw("Unable to determine function. Make sure the function has been correctly exported");
+    }).to.throw("The resolved entry point is not a function and cannot be invoked by the functions runtime. Make sure the function has been correctly exported.");
   });
   
   afterEach(() => {


### PR DESCRIPTION
Addresses issue: https://github.com/Azure/azure-functions-cli/issues/254

Reproduce steps
Configure a function for which the entry point doesn't return a function
e.g.: mistype module.exports and you'll end up with a valid entry point referencing an empty object

Proposed Solution
Improve the check and add a different message for when the entryPoint has been resolved but it is not a function
