### PR TITLE
Change to use TypeData for rawbody (to allow for undefined)

### DIFF
--- a/protos/FunctionRpc.proto
+++ b/protos/FunctionRpc.proto
@@ -252,5 +252,5 @@ message RpcHttp {
   string status_code = 12;
   map<string,string> query = 15;
   bool is_raw = 16;
-  string rawBody = 17;
+  TypedData rawBody = 17;
 }

--- a/src/Converters.ts
+++ b/src/Converters.ts
@@ -9,7 +9,7 @@ export function fromRpcHttp(rpcHttp: rpc.RpcHttp$Properties) {
     query: rpcHttp.query,
     params: rpcHttp.params,
     body: fromTypedData(rpcHttp.body),
-    rawBody: rpcHttp.rawBody,
+    rawBody: fromTypedData(rpcHttp.rawBody, false),
   };
 
   return httpContext;
@@ -27,13 +27,15 @@ export function toRpcHttp(inputMessage): rpc.TypedData$Properties {
   }
 }
 
-export function fromTypedData(typedData?: rpc.TypedData$Properties) {
+export function fromTypedData(typedData?: rpc.TypedData$Properties, convertStringToJson: boolean = true) {
   typedData = typedData || {};
   let str = typedData.string || typedData.json;
   if (str !== undefined) {
-    try {
-      str = JSON.parse(str);
-    } catch (err) { }
+    if (convertStringToJson) {
+      try {
+        str = JSON.parse(str);
+      } catch (err) { }
+    }
     return str;
   } else if (typedData.bytes) {
     return new Buffer(typedData.bytes);


### PR DESCRIPTION
Fixes an issue with the rawBody support for GET cases where it should be undefined (based on previous v1 behavior)