### PR TITLE
Opt-in to content negotiation instead of as default

### DIFF
--- a/protos/FunctionRpc.proto
+++ b/protos/FunctionRpc.proto
@@ -251,6 +251,6 @@ message RpcHttp {
   map<string,string> params = 10;
   string status_code = 12;
   map<string,string> query = 15;
-  bool is_raw = 16;
+  bool enableContentNegotiation = 16;
   TypedData rawBody = 17;
 }

--- a/src/http/Response.ts
+++ b/src/http/Response.ts
@@ -5,18 +5,13 @@ export class Response {
     statusCode?: string | number;
     headers: {[key:string]: any} = {};
     body?: any;
-    isRaw?: boolean;
+    enableContentNegotiation?: boolean;
     [key:string]: any;
 
     private _done: Function;
 
     constructor(done: Function) {
         this._done = done;
-    }
-
-    raw(body: any) {
-        this.isRaw = true;
-        return this.send(body);
     }
 
     end(body?: any) {


### PR DESCRIPTION
Changing the "isRaw" flag to "enableContentNegotiation". Requires corresponding change when pulled through in https://github.com/Azure/azure-functions-host.

Part 1 of addressing https://github.com/Azure/azure-functions-host/issues/2552

### Background ###
 - [Docs on content negotiation](https://docs.microsoft.com/en-us/aspnet/web-api/overview/formats-and-model-binding/content-negotiation) in ASP.NET web API (what we use in [azure-functions-host](https://www.github.com/azure/azure-functions-host))