### PR TITLE
Null check on bindingData value

### DIFF
--- a/src/Converters.ts
+++ b/src/Converters.ts
@@ -87,7 +87,7 @@ function convertKeysToCamelCase(obj: any) {
       let value = fromTypedData(obj[key]) || obj[key];
       let camelCasedKey = key.charAt(0).toLocaleLowerCase() + key.slice(1);
       // If the value is a JSON object (and not http, which is already cased), convert keys to camel case
-      if (typeof value === 'object' && value.http == undefined) {
+      if (typeof value === 'object' && value && value.http == undefined) {
         output[camelCasedKey] = convertKeysToCamelCase(value);
       } else {
         output[camelCasedKey] = value;

--- a/src/GrpcService.ts
+++ b/src/GrpcService.ts
@@ -2,7 +2,7 @@ import * as semver from 'semver';
 
 if (!semver.satisfies(process.version, '8.x')) {
   let errorMessage = `Your Function App is currently set to use current version ${process.version}, but the runtime requires Node 8.x.
-  Please change the app setting WEBSITE_NODE_DEFAULT_VERSION to 8.11.1 or change your local node version using 'nvm'`;
+  Please change the app setting WEBSITE_NODE_DEFAULT_VERSION to the latest 8.x or change your local node version using 'nvm'`;
   console.error(errorMessage);
   throw new Error(errorMessage);
 } 

--- a/src/GrpcService.ts
+++ b/src/GrpcService.ts
@@ -2,7 +2,7 @@ import * as semver from 'semver';
 
 if (!semver.satisfies(process.version, '8.x')) {
   let errorMessage = `Your Function App is currently set to use current version ${process.version}, but the runtime requires Node 8.x.
-  Please change the app setting WEBSITE_NODE_DEFAULT_VERSION to the latest 8.x or change your local node version using 'nvm'`;
+  For delpoyed code, please change WEBSITE_NODE_DEFAULT_VERSION in App Settings. On your local machine, you can change node version using 'nvm'`;
   console.error(errorMessage);
   throw new Error(errorMessage);
 } 


### PR DESCRIPTION
Values of binding data shouldn't be null, but could be. This comes up in our runtime E2E test cases.

Also updating node version error message to be a bit more informative 