### PR TITLE
Upgrading from deprecated Buffer method

### DIFF
--- a/src/Converters.ts
+++ b/src/Converters.ts
@@ -48,7 +48,7 @@ export function fromTypedData(typedData?: rpc.ITypedData, convertStringToJson: b
     }
     return str;
   } else if (typedData.bytes) {
-    return new Buffer(typedData.bytes);
+    return Buffer.from(typedData.bytes.buffer);
   }
 }
 


### PR DESCRIPTION
Resolves #98

Using node 10, nodejs worker shows this warning:
```
     (node:11736) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```