### PR TITLE
Update node version warning message

### DIFF
--- a/src/GrpcService.ts
+++ b/src/GrpcService.ts
@@ -2,7 +2,7 @@ import * as semver from 'semver';
 
 // If user is not using Node.js v8 or v10, fail
 if (!(semver.satisfies(process.version, '8.x') || semver.satisfies(process.version, '10.x'))) {
-    let errorMessage = `Your Function App is currently set to use Node.js version ${process.version}, but the runtime requires an 8.x or 10.x version (ex: 8.11.1 or 10.6.0).
+    let errorMessage = `Your Function App is currently set to use Node.js version ${process.version}, but the runtime requires an Active LTS or Current version (ex: 8.11.1 or 10.6.0).
     For deployed code, please change WEBSITE_NODE_DEFAULT_VERSION in App Settings. On your local machine, you can change node version using 'nvm' (make sure to quit and restart your code editor to pick up the changes).`;
     console.error(errorMessage);
     throw new Error(errorMessage);

--- a/src/GrpcService.ts
+++ b/src/GrpcService.ts
@@ -1,14 +1,11 @@
 import * as semver from 'semver';
 
-// If user is not using Node.js v10, warn to upgrade to v10
-if (!semver.satisfies(process.version, '10.x')) {
-    let errorMessage = `Your Function App is currently set to use Node.js version ${process.version}, but the runtime requires a 10.x version.
+// If user is not using Node.js v8 or v10, fail
+if (!(semver.satisfies(process.version, '8.x') || semver.satisfies(process.version, '10.x'))) {
+    let errorMessage = `Your Function App is currently set to use Node.js version ${process.version}, but the runtime requires an 8.x or 10.x version (ex: 8.11.1 or 10.6.0).
     For deployed code, please change WEBSITE_NODE_DEFAULT_VERSION in App Settings. On your local machine, you can change node version using 'nvm' (make sure to quit and restart your code editor to pick up the changes).`;
     console.error(errorMessage);
-    // Don't fail Node.js v8 users for now
-    if (!semver.satisfies(process.version, '8.x')) {
-        throw new Error(errorMessage);
-    }
+    throw new Error(errorMessage);
 }
 
 import { Duplex } from 'stream';


### PR DESCRIPTION
Previously, we were going to deprecate node v8. Now, we are supporting Active LTS and Current versions.

Updating messaging to reflect decision. Resolves #107