### PR TITLE
Better error message for wrong init node worker args

### DIFF
--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -10,7 +10,15 @@ export function startNodeWorker(args) {
   let { host, port, workerId, requestId, grpcMaxMessageLength } = parseArgs(args.slice(2));
   if (!host || !port || !workerId || !requestId || !grpcMaxMessageLength) {
     console.log('usage --host hostName --port portNumber --workerId workerId --requestId requestId --grpcMaxMessageLength grpcMaxMessageLength');
-    throw new Error('gRPC client connection info is missing or null. Check \'hostName\', \'portNumber\', \'workerId\', \'requestId\', and \'grpcMaxMessageLength\'');
+    // Find which arguments are in error
+    var debugInfo: string[] = [];
+    if (!host) debugInfo.push(`\'hostName\' is ${host}`);
+    if (!port) debugInfo.push(`\'port\' is ${port}`);
+    if (!workerId) debugInfo.push(`\'workerId\' is ${workerId}`);
+    if (!requestId) debugInfo.push(`\'requestId\' is ${requestId}`);
+    if (!grpcMaxMessageLength) debugInfo.push(`\'grpcMaxMessageLength\' is ${grpcMaxMessageLength}`);
+
+    throw new Error(`gRPC client connection info is missing or incorrect (${debugInfo.join(", ")}).`);
   }
 
   let connection = `${host}:${port}`;

--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -10,7 +10,7 @@ export function startNodeWorker(args) {
   let { host, port, workerId, requestId, grpcMaxMessageLength } = parseArgs(args.slice(2));
   if (!host || !port || !workerId || !requestId || !grpcMaxMessageLength) {
     console.log('usage --host hostName --port portNumber --workerId workerId --requestId requestId --grpcMaxMessageLength grpcMaxMessageLength');
-    throw new Error('Connection info missing');
+    throw new Error('gRPC client connection info is missing or null. Check \'hostName\', \'portNumber\', \'workerId\', \'requestId\', and \'grpcMaxMessageLength\'');
   }
 
   let connection = `${host}:${port}`;

--- a/test/WorkerTests.ts
+++ b/test/WorkerTests.ts
@@ -1,0 +1,15 @@
+import { startNodeWorker } from '../src/Worker';
+import { expect } from 'chai';
+import 'mocha';
+
+describe('Worker', () => {
+  it('throws error on incorrect args: grpcMaxMessageLength 0', () => {
+    var args = ["/node", "nodejsWorker.js", "--host", "120.0.0.0", "--port" ,"8000", "--workerId", "bd2e3e80-46ba", "--requestId", "bd2e3e80-46ba", "--grpcMaxMessageLength", "0"];
+    expect(() => { startNodeWorker(args) }).to.throw("gRPC client connection info is missing or incorrect ('grpcMaxMessageLength' is 0).");
+  });
+
+  it('throws error on incorrect args: grpcMaxMessageLength 0 and null requestId', () => {
+    var args = ["/node", "nodejsWorker.js", "--host", "120.0.0.0", "--port" ,"8000", "--workerId", "bd2e3e80-46ba", "--grpcMaxMessageLength", "0"];
+    expect(() => { startNodeWorker(args) }).to.throw("gRPC client connection info is missing or incorrect ('requestId' is undefined, 'grpcMaxMessageLength' is 0).");
+  });
+})


### PR DESCRIPTION
Helpful especially if there are azure-functions-host changes that result in missing or null worker start args.

REsolves #110