### PR TITLE
Revert "Upgrading from deprecated Buffer method (#103)"

### DIFF
--- a/src/Converters.ts
+++ b/src/Converters.ts
@@ -48,7 +48,7 @@ export function fromTypedData(typedData?: rpc.ITypedData, convertStringToJson: b
     }
     return str;
   } else if (typedData.bytes) {
-    return Buffer.from(typedData.bytes.buffer);
+    return new Buffer(typedData.bytes);
   }
 }
 


### PR DESCRIPTION
This reverts commit 12cf5df767bf28bc2c43471188491f03a2acc9ee.

Resolves issue where byte array data was not being converted properly in functions host.