### PR TITLE
Do not JSON.parse() array types

### DIFF
--- a/src/Converters.ts
+++ b/src/Converters.ts
@@ -88,7 +88,7 @@ function convertKeysToCamelCase(obj: any) {
   for (var key in obj) {
       let value = fromTypedData(obj[key]) || obj[key];
       let camelCasedKey = key.charAt(0).toLocaleLowerCase() + key.slice(1);
-      // If the value is a JSON object (and not http, which is already cased), convert keys to camel case
+      // If the value is a JSON object (and not array ahd not http, which is already cased), convert keys to camel case
       if (!Array.isArray(value) && typeof value === 'object' && value && value.http == undefined) {
         output[camelCasedKey] = convertKeysToCamelCase(value);
       } else {

--- a/src/Converters.ts
+++ b/src/Converters.ts
@@ -89,7 +89,7 @@ function convertKeysToCamelCase(obj: any) {
       let value = fromTypedData(obj[key]) || obj[key];
       let camelCasedKey = key.charAt(0).toLocaleLowerCase() + key.slice(1);
       // If the value is a JSON object (and not http, which is already cased), convert keys to camel case
-      if (typeof value === 'object' && value && value.http == undefined) {
+      if (!Array.isArray(value) && typeof value === 'object' && value && value.http == undefined) {
         output[camelCasedKey] = convertKeysToCamelCase(value);
       } else {
         output[camelCasedKey] = value;

--- a/src/Converters.ts
+++ b/src/Converters.ts
@@ -88,7 +88,7 @@ function convertKeysToCamelCase(obj: any) {
   for (var key in obj) {
       let value = fromTypedData(obj[key]) || obj[key];
       let camelCasedKey = key.charAt(0).toLocaleLowerCase() + key.slice(1);
-      // If the value is a JSON object (and not array ahd not http, which is already cased), convert keys to camel case
+      // If the value is a JSON object (and not array and not http, which is already cased), convert keys to camel case
       if (!Array.isArray(value) && typeof value === 'object' && value && value.http == undefined) {
         output[camelCasedKey] = convertKeysToCamelCase(value);
       } else {

--- a/test/ConvertersTests.ts
+++ b/test/ConvertersTests.ts
@@ -46,6 +46,9 @@ describe('Converters', () => {
         "SequenceNumberArray": {
             json: JSON.stringify([1, 2])
         },
+        "Properties": {
+            json: JSON.stringify({"Greetings": ["Hola", "Salut", "Konichiwa"], "SequenceNumber": [1, 2, 3]})
+        },
         "Sys": {
             json: JSON.stringify({MethodName: 'test-js', UtcNow: '2018', RandGuid: '3212'})
         }
@@ -63,10 +66,18 @@ describe('Converters', () => {
     expect(bindingData.enqueuedMessages[1]).to.equal("Hello 2");
     expect(Array.isArray(bindingData.sequenceNumberArray)).to.be.true;
     expect(bindingData.sequenceNumberArray.length).to.equal(2);
-    expect(bindingData.sequenceNumberArray[1]).to.equal(2);
+    expect(bindingData.sequenceNumberArray[0]).to.equal(1);
     expect(bindingData.sys.methodName).to.equal('test-js');
     expect(bindingData.sys.utcNow).to.equal('2018');
     expect(bindingData.sys.randGuid).to.equal('3212');
+    // Verify that nested arrays are converted correctly
+    let properties = bindingData.properties;
+    expect(Array.isArray(properties.greetings)).to.be.true;
+    expect(properties.greetings.length).to.equal(3);
+    expect(properties.greetings[1]).to.equal("Salut");
+    expect(Array.isArray(properties.sequenceNumber)).to.be.true;
+    expect(properties.sequenceNumber.length).to.equal(3);
+    expect(properties.sequenceNumber[0]).to.equal(1);
     // Verify accessing original keys is undefined
     expect(bindingData.Sys).to.be.undefined;
     expect(bindingData.sys.UtcNow).to.be.undefined;

--- a/test/ConvertersTests.ts
+++ b/test/ConvertersTests.ts
@@ -5,7 +5,7 @@ import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-wo
 import 'mocha';
 
 describe('Converters', () => {
-  it('normalizes binding trigger metadata', () => {
+  it('normalizes binding trigger metadata for HTTP', () => {
     var mockRequest: rpc.ITypedData = toRpcHttp({ url: "https://mock"});
     var triggerDataMock: { [k: string]: rpc.ITypedData } = {
         "Headers": {
@@ -33,6 +33,40 @@ describe('Converters', () => {
     expect(bindingData.sys.utcNow).to.equal('2018');
     expect(bindingData.sys.randGuid).to.equal('3212');
     expect(bindingData.$request).to.equal('Https://mock/');
+    // Verify accessing original keys is undefined
+    expect(bindingData.Sys).to.be.undefined;
+    expect(bindingData.sys.UtcNow).to.be.undefined;
+  });
+
+  it('normalizes binding trigger metadata containing arrays', () => {
+    var triggerDataMock: { [k: string]: rpc.ITypedData } = {
+        "EnqueuedMessages": {
+            json: JSON.stringify(["Hello 1", "Hello 2"])
+        },
+        "SequenceNumberArray": {
+            json: JSON.stringify([1, 2])
+        },
+        "Sys": {
+            json: JSON.stringify({MethodName: 'test-js', UtcNow: '2018', RandGuid: '3212'})
+        }
+    };
+    var request: rpc.IInvocationRequest = <rpc.IInvocationRequest> {
+        triggerMetadata: triggerDataMock,
+        invocationId: "12341"
+    }
+    
+    var bindingData = getNormalizedBindingData(request);
+    // Verify conversion to camelCase
+    expect(bindingData.invocationId).to.equal('12341');
+    expect(Array.isArray(bindingData.enqueuedMessages)).to.be.true;
+    expect(bindingData.enqueuedMessages.length).to.equal(2);
+    expect(bindingData.enqueuedMessages[1]).to.equal("Hello 2");
+    expect(Array.isArray(bindingData.sequenceNumberArray)).to.be.true;
+    expect(bindingData.sequenceNumberArray.length).to.equal(2);
+    expect(bindingData.sequenceNumberArray[1]).to.equal(2);
+    expect(bindingData.sys.methodName).to.equal('test-js');
+    expect(bindingData.sys.utcNow).to.equal('2018');
+    expect(bindingData.sys.randGuid).to.equal('3212');
     // Verify accessing original keys is undefined
     expect(bindingData.Sys).to.be.undefined;
     expect(bindingData.sys.UtcNow).to.be.undefined;


### PR DESCRIPTION
Parsing JavaScript array types leaves us with JSON objects that look like:
{ "0": "item 1", "1": "item 2" }

Resolves #125