### PR TITLE
Return a promise returned from a user function

### DIFF
--- a/src/FunctionLoader.ts
+++ b/src/FunctionLoader.ts
@@ -59,7 +59,7 @@ function getEntryPoint(f: any, entryPoint?: string): Function {
 
         if (isFunction(f)){
             return function() {
-                f.apply(obj, arguments);
+                return f.apply(obj, arguments);
             }
         }
     }

--- a/test/FunctionLoaderTests.ts
+++ b/test/FunctionLoaderTests.ts
@@ -89,6 +89,21 @@ describe('FunctionLoader', () => {
     });
   });
   
+  it ('allows to return a promise from async user function', () => {
+    mock('test', { test: async () => {} });
+
+    loader.load('functionId', <rpc.IRpcFunctionMetadata> {
+        scriptFile: 'test',
+        entryPoint: 'test'
+    });
+
+    var userFunction = loader.getFunc('functionId');
+    var result = userFunction();
+
+    expect(result).to.be.not.an('undefined');
+    expect(result.then).to.be.a('function');
+  });
+
   afterEach(() => {
     mock.stopAll()
   });


### PR DESCRIPTION
Without added return the rejected async user function would cause an unhandled promise warning and failure to enact implicit call to context.done, which results in function timing out after 5 minutes.

@mhoeger This issue was introduced at https://github.com/Azure/azure-functions-nodejs-worker/commit/44410b6ae2cc9c786e887b2ff127c541cfc26476 when implementing `this` support for user functions.