### PR TITLE
Check for valid version and provide good error if it is invalid

### DIFF
--- a/src/nodejsWorker.ts
+++ b/src/nodejsWorker.ts
@@ -1,10 +1,62 @@
 var logPrefix = "LanguageWorkerConsoleLog";
 var worker;
+var MIN_MAJOR_VERSION = 10;
+
 try {
-    worker = require("../../worker-bundle.js");
+  var parts = process.version.split(".");
+  if (parts.length < 1) {
+    var error = new Error("Could not parse Node.js version");
+    throw {
+      error: error,
+      versionTooLow: undefined
+    };
+  }
+
+  var major = parseInt(parts[0], 10);
+  if (major < MIN_MAJOR_VERSION) {
+    var error = new Error(
+      "Invalid Node.js version. Must use version greater than 10.0.0"
+    );
+    throw {
+      error: error,
+      versionTooLow: undefined
+    };
+  }
 } catch (err) {
-    console.error(`${logPrefix}Couldn't require bundle, falling back to Worker.js. ${err}`);
-    worker = require("./Worker.js");
+  if (err && err.versionTooLow) {
+    console.error(
+      "Node.js version is too low. Current version " +
+        process.version +
+        ". Please use a version greater than " +
+        MIN_MAJOR_VERSION
+    );
+  } else {
+    console.error(
+      "Could not parse Node.js version. Current version " +
+        process.version +
+        ". Be sure your Node.js version is greater than " +
+        MIN_MAJOR_VERSION
+    );
+  }
+  if (err.error) {
+    throw err.error;
+  } else {
+    throw new Error(
+      "Could not parse Node.js version. Current version " +
+        process.version +
+        ". Be sure your Node.js version is greater than " +
+        MIN_MAJOR_VERSION
+    );
+  }
+}
+
+try {
+  worker = require("../../worker-bundle.js");
+} catch (err) {
+  console.error(
+    `${logPrefix}Couldn't require bundle, falling back to Worker.js. ${err}`
+  );
+  worker = require("./Worker.js");
 }
 
 worker.startNodeWorker(process.argv);


### PR DESCRIPTION
This adds a check for Node.js v10 before continuing on.

I kind of just slashed this together. Probably need a proper test to check that it fails nicely. You'll need to run the test against 0.10.4 for it to do any good on App Service.

We could move it to a helper method and require it in to help unit test it more effectively, but it needs to be resilient to 0.10.4/etc., so I kept it simple for now.

Feel free to close this in favor of your own implementation if you have a different idea on how to enforce this.