### PR TITLE
Refactor to isolate public interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,4 @@ test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2
 
 # Keeps internal utility functions from getting exported
 types
-!types/public/Interfaces.d.ts
+!*/types/public/Interfaces.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,7 @@ test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2
 test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/obj
 
 # Keeps internal utility functions from getting exported
-types
-!*/types/public/Interfaces.d.ts
+types/*
+!types/public
+types/public/*
+!types/public/Interfaces.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ test/end-to-end/Azure.Functions.NodejsWorker.E2E/.vs
 test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/bin
 test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/obj
 
-# Publishes external interfaces
+# Commit external interfaces
 types/*
 
 !types/public

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ test/end-to-end/testFunctionApp/obj
 test/end-to-end/Azure.Functions.NodejsWorker.E2E/.vs
 test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/bin
 test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/obj
+
+# Keeps internal utility functions from getting exported
+types
+!types/public/Interfaces.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -48,8 +48,9 @@ test/end-to-end/Azure.Functions.NodejsWorker.E2E/.vs
 test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/bin
 test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/obj
 
-# Keeps internal utility functions from getting exported
+# Publishes external interfaces
 types/*
+
 !types/public
 types/public/*
 !types/public/Interfaces.d.ts

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -4,18 +4,7 @@ import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-wo
 import { Request, HttpRequest } from './http/Request';
 import { Response } from './http/Response';
 import LogLevel = rpc.RpcLog.Level;
-
-export interface IContext {
-  invocationId: string;
-  executionContext: IExecutionContext;
-  bindings: IDict<any>;
-  bindingData: IDict<any>;
-  bindingDefinitions: IDict<any>[];
-  log: ILogger;
-  req?: Request;
-  res?: Response;
-  done: IDoneCallback;
-};
+import { IContext, IDict, IExecutionContext, ILogger, IDoneCallback } from './public/Interfaces' 
 
 export function CreateContextAndInputs(info: FunctionInfo, request: rpc.IInvocationRequest, logCallback: ILogCallback, callback: IResultCallback) {
   let context = new Context(info, request, logCallback, callback);
@@ -115,35 +104,10 @@ export interface IInvocationResult {
   bindings: IDict<any>;
 }
 
-export interface ILog {
-  (...args: any[]): void;
-}
-
-export interface ILogger extends ILog {
-  error: ILog;
-  warn: ILog;
-  info: ILog;
-  verbose: ILog;
-}
-
 export interface ILogCallback {
   (level: LogLevel, ...args: any[]): void;
 }
 
 export interface IResultCallback {
   (err?: any, result?: IInvocationResult): void;
-}
-
-export interface IDoneCallback {
-  (err?: any, result?: any): void;
-}
-
-export interface IExecutionContext {
-  invocationId: string;
-  functionName: string;
-  functionDirectory: string;
-}
-
-export interface IDict<T> {
-  [key: string]: T
 }

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -4,7 +4,7 @@ import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-wo
 import { Request, HttpRequest } from './http/Request';
 import { Response } from './http/Response';
 import LogLevel = rpc.RpcLog.Level;
-import { IContext, IDict, IExecutionContext, ILogger, IDoneCallback } from './public/Interfaces' 
+import { IContext, IExecutionContext, ILogger, IDoneCallback } from './public/Interfaces' 
 
 export function CreateContextAndInputs(info: FunctionInfo, request: rpc.IInvocationRequest, logCallback: ILogCallback, callback: IResultCallback) {
   let context = new Context(info, request, logCallback, callback);
@@ -110,4 +110,8 @@ export interface ILogCallback {
 
 export interface IResultCallback {
   (err?: any, result?: IInvocationResult): void;
+}
+
+export interface IDict<T> {
+  [key: string]: T
 }

--- a/src/Converters.ts
+++ b/src/Converters.ts
@@ -1,7 +1,7 @@
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
 import { FunctionInfo } from './FunctionInfo';
 import { HttpRequest } from './http/Request';
-import { IDict } from './public/Interfaces';
+import { IDict } from '../src/Context';
 export function fromRpcHttp(rpcHttp: rpc.IRpcHttp) {
   let httpContext: HttpRequest = {
     method: <string>rpcHttp.method,

--- a/src/Converters.ts
+++ b/src/Converters.ts
@@ -1,7 +1,7 @@
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
 import { FunctionInfo } from './FunctionInfo';
 import { HttpRequest } from './http/Request';
-import { IDict } from './Context';
+import { IDict } from './public/Interfaces';
 export function fromRpcHttp(rpcHttp: rpc.IRpcHttp) {
   let httpContext: HttpRequest = {
     method: <string>rpcHttp.method,

--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -1,4 +1,3 @@
-import { Duplex } from 'stream';
 import { format, isFunction } from 'util';
 
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';

--- a/src/http/Request.ts
+++ b/src/http/Request.ts
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
+import { IRequest } from '../public/Interfaces';
 
 export class HttpRequest {
     method: string = "";
@@ -13,13 +14,13 @@ export class HttpRequest {
     [key:string]: any;
 }
 
-export class Request extends HttpRequest {
+export class Request extends HttpRequest implements IRequest {
     constructor(httpInput: HttpRequest) {
         super();
         Object.assign(this, httpInput);
     }
 
-    get(field: string) {
+    get(field: string): string | undefined {
         return this.headers && this.headers[field.toLowerCase()];
     }
 }

--- a/src/http/Response.ts
+++ b/src/http/Response.ts
@@ -1,7 +1,8 @@
 // Copyright (c) .NET Foundation. All rights thiserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
+import { IResponse } from '../public/Interfaces';
 
-export class Response {
+export class Response implements IResponse {
     statusCode?: string | number;
     headers: {[key:string]: any} = {};
     body?: any;
@@ -23,28 +24,28 @@ export class Response {
         return this;
     }
 
-    setHeader(field: string, val: any) {
+    setHeader(field: string, val: any): IResponse  {
         this.headers[field.toLowerCase()] = val;
         return this;
     }
 
-    getHeader(field: string) {
+    getHeader(field: string): IResponse {
         return this.headers[field.toLowerCase()];
     }
 
-    removeHeader(field: string){
+    removeHeader(field: string) {
         delete this.headers[field.toLowerCase()];
         return this;
     }
 
-    status(statusCode: string | number){
+    status(statusCode: string | number): IResponse {
         this.statusCode = statusCode;
         return this;
     }
 
-    sendStatus(statusCode: string | number){
-        return this.status(statusCode)
-            .end();
+    sendStatus(statusCode: string | number) {
+        this.status(statusCode);
+        return this.end();
     }
 
     type(type){
@@ -52,12 +53,14 @@ export class Response {
     }
 
     json(body){
-        return this.type('application/json')
-            .send(body);
+        this.type('application/json');
+        this.send(body);
+        return;
     }
 
     send = this.end;
-    header = this.set = this.setHeader;
+    header = this.setHeader;
+    set = this.setHeader;
     get = this.getHeader;
     
     private setContentType() {

--- a/src/public/Interfaces.ts
+++ b/src/public/Interfaces.ts
@@ -1,0 +1,58 @@
+export interface IContext {
+    invocationId: string;
+    executionContext: IExecutionContext;
+    bindings: IDict<any>;
+    bindingData: IDict<any>;
+    bindingDefinitions: IDict<any>[];
+    log: ILogger;
+    req?: IRequest;
+    res?: IResponse;
+    done: IDoneCallback;
+};
+
+export interface IExecutionContext {
+    invocationId: string;
+    functionName: string;
+    functionDirectory: string;
+}
+
+export interface IDict<T> {
+    [key: string]: T
+}
+ 
+export interface ILog {
+    (...args: any[]): void;
+}
+  
+export interface ILogger extends ILog {
+    error: ILog;
+    warn: ILog;
+    info: ILog;
+    verbose: ILog;
+}
+
+export interface IRequest {
+    method: string;
+    url: string;
+    originalUrl: string;
+    headers?: {[key:string]: string};
+    query?: {[key:string]: string};
+    params?: {[key:string]: string};
+    body?: any;
+    rawbody?: any;
+    get(field: string): string | undefined;
+}
+
+export interface IResponse {
+    statusCode?: string | number;
+    headers: {[key:string]: any};
+    body?: any;
+    get(field: string): any;
+    set(field: string, val: any): IResponse;
+    header(field: string, val: any): IResponse;
+    status(statusCode: string | number): IResponse;
+}
+
+export interface IDoneCallback {
+    (err?: any, result?: any): void;
+}

--- a/src/public/Interfaces.ts
+++ b/src/public/Interfaces.ts
@@ -1,9 +1,9 @@
 export interface IContext {
     invocationId: string;
     executionContext: IExecutionContext;
-    bindings: IDict<any>;
-    bindingData: IDict<any>;
-    bindingDefinitions: IDict<any>[];
+    bindings: { [key: string]: any };
+    bindingData: { [key: string]: any };
+    bindingDefinitions: { [key: string]: any };
     log: ILogger;
     req?: IRequest;
     res?: IResponse;
@@ -16,10 +16,6 @@ export interface IExecutionContext {
     functionDirectory: string;
 }
 
-export interface IDict<T> {
-    [key: string]: T
-}
- 
 export interface ILog {
     (...args: any[]): void;
 }

--- a/test/ContextTests.ts
+++ b/test/ContextTests.ts
@@ -1,7 +1,7 @@
-import { IContext, CreateContextAndInputs, ILogCallback, IResultCallback } from '../src/Context';
+import { CreateContextAndInputs, ILogCallback, IResultCallback } from '../src/Context';
+import { IContext } from "../src/public/Interfaces";
 import { FunctionInfo } from '../src/FunctionInfo';
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
-import { expect } from 'chai';
 import * as sinon from 'sinon';
 import 'mocha';
 

--- a/test/FunctionLoaderTests.ts
+++ b/test/FunctionLoaderTests.ts
@@ -1,11 +1,9 @@
 import { WorkerChannel } from '../src/WorkerChannel';
 import { FunctionLoader } from '../src/FunctionLoader';
 import { expect } from 'chai';
-import * as sinon from 'sinon';
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
 import 'mocha';
 import mock = require('mock-require');
-import { isObject } from 'util';
 
 describe('FunctionLoader', () => {
   var channel: WorkerChannel;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
         "noImplicitAny": false,
         "strict": true,
         "outDir": "dist/src",
-        "sourceMap": true
+        "sourceMap": true,
+        "declaration": true,
+        "declarationDir": "types"
     },
     "include": [
         "src/**/*"

--- a/types/public/Interfaces.d.ts
+++ b/types/public/Interfaces.d.ts
@@ -3,6 +3,7 @@ export interface IContext {
     executionContext: IExecutionContext;
     bindings: IDict<any>;
     bindingData: IDict<any>;
+    bindingDefinitions: IDict<any>[];
     log: ILogger;
     req?: IRequest;
     res?: IResponse;

--- a/types/public/Interfaces.d.ts
+++ b/types/public/Interfaces.d.ts
@@ -1,0 +1,58 @@
+export interface IContext {
+    invocationId: string;
+    executionContext: IExecutionContext;
+    bindings: IDict<any>;
+    bindingData: IDict<any>;
+    log: ILogger;
+    req?: IRequest;
+    res?: IResponse;
+    done: IDoneCallback;
+}
+export interface IExecutionContext {
+    invocationId: string;
+    functionName: string;
+    functionDirectory: string;
+}
+export interface IDict<T> {
+    [key: string]: T;
+}
+export interface ILog {
+    (...args: any[]): void;
+}
+export interface ILogger extends ILog {
+    error: ILog;
+    warn: ILog;
+    info: ILog;
+    verbose: ILog;
+}
+export interface IRequest {
+    method: string;
+    url: string;
+    originalUrl: string;
+    headers?: {
+        [key: string]: string;
+    };
+    query?: {
+        [key: string]: string;
+    };
+    params?: {
+        [key: string]: string;
+    };
+    body?: any;
+    rawbody?: any;
+    get(field: string): string | undefined;
+}
+export interface IResponse {
+    statusCode?: string | number;
+    headers: {
+        [key: string]: any;
+    };
+    body?: any;
+    get(field: string): any;
+    set(field: string, val: any): IResponse;
+    header(field: string, val: any): IResponse;
+    status(statusCode: string | number): IResponse;
+}
+export interface IDoneCallback {
+    (err?: any, result?: any): void;
+}

--- a/types/public/Interfaces.d.ts
+++ b/types/public/Interfaces.d.ts
@@ -1,9 +1,15 @@
 export interface IContext {
     invocationId: string;
     executionContext: IExecutionContext;
-    bindings: IDict<any>;
-    bindingData: IDict<any>;
-    bindingDefinitions: IDict<any>[];
+    bindings: {
+        [key: string]: any;
+    };
+    bindingData: {
+        [key: string]: any;
+    };
+    bindingDefinitions: {
+        [key: string]: any;
+    };
     log: ILogger;
     req?: IRequest;
     res?: IResponse;
@@ -13,9 +19,6 @@ export interface IExecutionContext {
     invocationId: string;
     functionName: string;
     functionDirectory: string;
-}
-export interface IDict<T> {
-    [key: string]: T;
 }
 export interface ILog {
     (...args: any[]): void;


### PR DESCRIPTION
This is step 1 to publishing typings. Idea is that `src/public/Interfaces` is the only file that will have typings generated from it and published ~~(either to @ types or as an npm package)~~ to @ types

Linked to https://github.com/Azure/azure-functions-nodejs-worker/issues/27