### PR TITLE
Incompatible Node.js version error message fix.

### DIFF
--- a/src/nodejsWorker.ts
+++ b/src/nodejsWorker.ts
@@ -19,7 +19,7 @@ function validateNodeVersion(version) {
         } else if (major != ACTIVE_LTS_VERSION && major != CURRENT_BRANCH_VERSION) {
             message = "Incompatible Node.js version. The version you are using is "
                     + version +
-                    ", but the runtime requires an Active LTS or Current version (ex: 8.11.1 or 10.6.0). "
+                    ", but the runtime requires an even-numbered Active LTS or Current version (ex: 8.11.1 or 10.6.0). "
                     + "For deployed code, change WEBSITE_NODE_DEFAULT_VERSION in App Settings. Locally, upgrade the node version used by your machine (make sure to quit and restart your code editor to pick up the changes).";
         }
     // Unknown error

--- a/src/nodejsWorker.ts
+++ b/src/nodejsWorker.ts
@@ -17,7 +17,7 @@ function validateNodeVersion(version) {
             message = "Could not parse Node.js version: '" + version + "'";
         // Unsupported version
         } else if (major != ACTIVE_LTS_VERSION && major != CURRENT_BRANCH_VERSION) {
-            message = "Node.js version is too low. The version you are using is "
+            message = "Incompatible Node.js version. The version you are using is "
                     + version +
                     ", but the runtime requires an Active LTS or Current version (ex: 8.11.1 or 10.6.0). "
                     + "For deployed code, change WEBSITE_NODE_DEFAULT_VERSION in App Settings. Locally, upgrade the node version used by your machine (make sure to quit and restart your code editor to pick up the changes).";


### PR DESCRIPTION
### Issue
When using a version of Node that is not an Active LTS or Current version (ex. 11.3.0), the runtime currently reports "Node.js version is too low." This can lead to logically inconsistent statements, ex.

`[error] Node.js version is too low. The version you are using is v11.3.0, but the runtime requires an Active LTS or Current version (ex: 8.11.1 or 10.60.)`

### Fix
Reworded error message to be more generic.