### PR TITLE
Add a strong type for 'direction'

### DIFF
--- a/types/public/Interfaces.d.ts
+++ b/types/public/Interfaces.d.ts
@@ -96,11 +96,11 @@ export interface IRequest {
         [key: string]: string;
     };
     /**
-     * The HTTP request body
+     * The HTTP request body.
      */
     body?: any;
     /**
-     * The HTTP request body as a UTF-8 string
+     * The HTTP request body as a UTF-8 string.
      */
     rawbody?: any;
 }

--- a/types/public/Interfaces.d.ts
+++ b/types/public/Interfaces.d.ts
@@ -129,9 +129,9 @@ export interface IBindingDefinition {
      */
     type: string;
     /**
-     * The direction of your binding ('in', 'out', or 'inout'), as defined in function.json.
+     * The direction of your binding, as defined in function.json.
      */
-    direction: string;
+    direction: 'in', 'out', 'inout';
 }
 export interface ILog {
     (...args: any[]): void;


### PR DESCRIPTION
Assuming that the comment about direction being either 'in', 'out' or 'inout' to be correct.