### PR TITLE
Update package.json

### DIFF
--- a/types/public/package.json
+++ b/types/public/package.json
@@ -2,7 +2,6 @@
   "name": "@azure/functions",
   "version": "1.0.1-beta2",
   "description": "Azure Functions types for Typescript",
-  "main": "Interfaces.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-functions-nodejs-worker/tree/master/types/public"

--- a/types/public/package.json
+++ b/types/public/package.json
@@ -11,6 +11,7 @@
     "azure-functions",
     "typescript"
   ],
+  "types": "./Interfaces.d.ts",
   "author": "Microsoft",
   "license": "MIT"
 }


### PR DESCRIPTION
Without the "types" property, TypeScript can't auto-discover the types properly.