### PR TITLE
Refactor: Use xUnit's collection fixtures.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,7 @@ build_script:
 test_script:
 - npm run test
 - ps: .\setup-e2e-tests.ps1
+- ps: .\run-e2e-tests.ps1
 
 artifacts:
 - path: 'pkg/*.nupkg'

--- a/azure-functions-language-worker-protobuf/README.md
+++ b/azure-functions-language-worker-protobuf/README.md
@@ -24,7 +24,7 @@ From within the Azure Functions language worker repo:
 
 From within the Azure Functions language worker repo:
 1.	Define remote branch for cleaner git commands
-    -	`git remote add proto-file https://github.com/mhoeger/azure-functions-language-worker-protobuf.git`
+    -	`git remote add proto-file https://github.com/azure/azure-functions-language-worker-protobuf.git`
     -	`git fetch proto-file`
 2.	Merge updates
     -   `git merge -s subtree proto-file/<version branch> --squash --allow-unrelated-histories` 

--- a/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
+++ b/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
@@ -5,10 +5,12 @@ option java_multiple_files = true;
 option java_package = "com.microsoft.azure.functions.rpc.messages";
 option java_outer_classname = "FunctionProto";
 option csharp_namespace = "Microsoft.Azure.WebJobs.Script.Grpc.Messages";
+option go_package ="github.com/Azure/azure-functions-go-worker/internal/rpc";
 
 package AzureFunctionsRpcMessages;
 
 import "google/protobuf/duration.proto";
+import "identity/ClaimsIdentityRpc.proto";
 
 // Interface exported by the server.
 service FunctionRpc {
@@ -64,6 +66,10 @@ message StreamingMessage {
 
     // Worker logs a message back to the host
     RpcLog rpc_log = 2;
+
+    FunctionEnvironmentReloadRequest function_environment_reload_request = 25;
+
+    FunctionEnvironmentReloadResponse function_environment_reload_response = 26;
   }
 }
 
@@ -179,6 +185,16 @@ message WorkerStatusRequest{
 message WorkerStatusResponse {
 }
 
+message FunctionEnvironmentReloadRequest {
+  // Environment variables from the current process
+  map<string, string> environment_variables = 1;
+}
+
+message FunctionEnvironmentReloadResponse {
+  // Status of the response
+  StatusResult result = 3;
+}
+
 // Host tells the worker to load a Function
 message FunctionLoadRequest {
   // unique function identifier (avoid name collisions, facilitate reload case)
@@ -286,11 +302,21 @@ message BindingInfo {
       inout = 2;
     }
 
+    // Indicates the type of the data for the binding
+    enum DataType {
+      undefined = 0;
+      string = 1;
+      binary = 2;
+      stream = 3;
+    }
+
   // Type of binding (e.g. HttpTrigger)
   string type = 2;
 
   // Direction of the given binding
   Direction direction = 3;
+
+  DataType data_type = 4;
 }
 
 // Used to send logs back to the Host 
@@ -354,4 +380,5 @@ message RpcHttp {
   map<string,string> query = 15;
   bool enable_content_negotiation= 16;
   TypedData rawBody = 17;
+  repeated RpcClaimsIdentity identities = 18;
 }

--- a/azure-functions-language-worker-protobuf/src/proto/identity/ClaimsIdentityRpc.proto
+++ b/azure-functions-language-worker-protobuf/src/proto/identity/ClaimsIdentityRpc.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+// protobuf vscode extension: https://marketplace.visualstudio.com/items?itemName=zxh404.vscode-proto3
+
+// Light-weight representation of a .NET System.Security.Claims.ClaimsIdentity object.
+// This is the same serialization as found in EasyAuth, and needs to be kept in sync with
+// its ClaimsIdentitySlim definition, as seen in the WebJobs extension:
+// https://github.com/Azure/azure-webjobs-sdk-extensions/blob/dev/src/WebJobs.Extensions.Http/ClaimsIdentitySlim.cs
+message RpcClaimsIdentity {
+  string authentication_type = 1;
+  string name_claim_type = 2;
+  string role_claim_type = 3;
+  repeated RpcClaim claims = 4;
+}
+
+// Light-weight representation of a .NET System.Security.Claims.Claim object.
+// This is the same serialization as found in EasyAuth, and needs to be kept in sync with
+// its ClaimSlim definition, as seen in the WebJobs extension:
+// https://github.com/Azure/azure-webjobs-sdk-extensions/blob/dev/src/WebJobs.Extensions.Http/ClaimSlim.cs
+message RpcClaim {
+  string value = 1;
+  string type = 2;
+}

--- a/setup-e2e-tests.ps1
+++ b/setup-e2e-tests.ps1
@@ -52,20 +52,3 @@ cd "$currDir\test\end-to-end\testFunctionApp"
 }
 StopOnFailedExecution
 cd $currDir
-
-Write-Host "Starting functions host..."
-$proc = start-process -NoNewWindow -PassThru -filepath "$currDir\Azure.Functions.Cli\func.exe" -WorkingDirectory "$currDir\test\end-to-end\testFunctionApp" -ArgumentList "host start" -RedirectStandardOutput "output.txt"
-Start-Sleep -s 30
-
-Write-Host "Running E2E tests..."
-./run-e2e-tests.ps1
-
-Write-Host "Closing process..."
-Stop-Process -Id $proc.Id -Erroraction Ignore 
-
-Write-Host "Host Logs:"
-$host_logs = Get-Content -Path "output.txt" -Raw
-Write-Host $host_logs
-
-StopOnFailedExecution
-Remove-Item -Path "output.txt"

--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E.csproj
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.1.1" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.2.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.2" />

--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/Constants.cs
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/Constants.cs
@@ -43,5 +43,8 @@ namespace Azure.Functions.NodeJs.Tests.E2E
                 public static string OutputName = "test-output-one-node";
             }
         }
+
+        // Xunit Fixtures and Collections
+        public const string FunctionAppCollectionName = "FunctionAppCollection";
     }
 }

--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/CosmosDBEndToEndTests.cs
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/CosmosDBEndToEndTests.cs
@@ -7,8 +7,16 @@ using Xunit;
 
 namespace Azure.Functions.NodeJs.Tests.E2E
 {
+    [Collection(Constants.FunctionAppCollectionName)]
     public class CosmosDBEndToEndTests 
     {
+        private readonly FunctionAppFixture _fixture;
+
+        public CosmosDBEndToEndTests(FunctionAppFixture fixture)
+        {
+            this._fixture = fixture;
+        }
+
         [Fact]
         public async Task CosmosDBTriggerAndOutput_Succeeds()
         {

--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/EventHubsEndToEndTests.cs
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/EventHubsEndToEndTests.cs
@@ -10,8 +10,16 @@ using Xunit;
 
 namespace Azure.Functions.NodeJs.Tests.E2E
 {
+    [Collection(Constants.FunctionAppCollectionName)]
     public class EventHubsEndToEndTests 
     {
+        private readonly FunctionAppFixture _fixture;
+
+        public EventHubsEndToEndTests(FunctionAppFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
         [Fact]
         public async Task EventHubTriggerAndOutputJSON_Succeeds()
         {

--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/Fixtures/FixtureHelpers.cs
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/Fixtures/FixtureHelpers.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace Azure.Functions.NodeJs.Tests.E2E
+{
+    public static class FixtureHelpers
+    {
+        public static Process GetFuncHostProcess(bool enableAuth = false)
+        {
+            var funcProcess = new Process();
+            var rootDir = Path.GetFullPath(@"..\..\..\..\..\..\..");
+
+            funcProcess.StartInfo.UseShellExecute = false;
+            funcProcess.StartInfo.CreateNoWindow = true;
+            funcProcess.StartInfo.WorkingDirectory = Path.Combine(rootDir, @"test\end-to-end\testFunctionApp");
+            funcProcess.StartInfo.FileName = Path.Combine(rootDir, @"Azure.Functions.Cli\func.exe");
+            funcProcess.StartInfo.ArgumentList.Add("start");
+            if (enableAuth)
+            {
+                funcProcess.StartInfo.ArgumentList.Add("--enableAuth");
+            }
+
+            return funcProcess;
+        }
+
+        public static void KillExistingFuncHosts()
+        {
+            foreach (var func in Process.GetProcessesByName("func"))
+            {
+                func.Kill();
+            }
+        }
+    }
+}

--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/Fixtures/FunctionAppFixture.cs
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/Fixtures/FunctionAppFixture.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Azure.Functions.NodeJs.Tests.E2E
+{
+    public class FunctionAppFixture : IDisposable
+    {
+        private readonly ILogger _logger;
+        private bool _disposed;
+        private Process _funcProcess;
+
+        public FunctionAppFixture()
+        {
+            // initialize logging
+#pragma warning disable CS0618 // Type or member is obsolete
+            ILoggerFactory loggerFactory = new LoggerFactory().AddConsole();
+#pragma warning restore CS0618 // Type or member is obsolete
+            _logger = loggerFactory.CreateLogger<FunctionAppFixture>();
+
+            // initialize environment
+
+            // kill existing func processes
+            _logger.LogInformation("Shutting down any running functions hosts..");
+            FixtureHelpers.KillExistingFuncHosts();
+
+            // start functions process
+            _logger.LogInformation($"Starting functions host for {Constants.FunctionAppCollectionName}..");
+            _funcProcess = FixtureHelpers.GetFuncHostProcess();
+            _funcProcess.Start();
+
+            Thread.Sleep(TimeSpan.FromSeconds(30));
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _logger.LogInformation("FunctionAppFixture disposing.");
+                    
+                    _logger.LogInformation($"Shutting down functions host for {Constants.FunctionAppCollectionName}");
+                    _funcProcess?.Kill();
+                    _funcProcess?.Dispose();
+                }
+
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+    }
+
+    [CollectionDefinition(Constants.FunctionAppCollectionName)]
+    public class FunctionAppCollection : ICollectionFixture<FunctionAppFixture>
+    {
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.
+    }
+}

--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/HttpEndToEndTests.cs
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/HttpEndToEndTests.cs
@@ -7,8 +7,16 @@ using Xunit;
 
 namespace Azure.Functions.NodeJs.Tests.E2E
 {
+    [Collection(Constants.FunctionAppCollectionName)]
     public class HttpEndToEndTests 
     {
+        private readonly FunctionAppFixture _fixture;
+
+        public HttpEndToEndTests(FunctionAppFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
         [Theory]
         [InlineData("HttpTrigger", "?name=Test", HttpStatusCode.OK, "Hello Test")]
         [InlineData("HttpTrigger", "?name=John&lastName=Doe", HttpStatusCode.OK, "Hello John")]

--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/StorageEndToEndTests.cs
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/StorageEndToEndTests.cs
@@ -7,8 +7,16 @@ using Xunit;
 
 namespace Azure.Functions.NodeJs.Tests.E2E
 {
+    [Collection(Constants.FunctionAppCollectionName)]
     public class StorageEndToEndTests 
     {
+        private FunctionAppFixture _fixture;
+
+        public StorageEndToEndTests(FunctionAppFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
         [Fact]
         public async Task QueueTriggerAndOutput_Succeeds()
         {


### PR DESCRIPTION
Per offline discussion, this refactoring:

- removes the need to write test output to .txt file
- isolates test environments, useful for tests that require specific settings