### PR TITLE
Refactored end-to-end tests to use xUnit's collection fixtures.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,7 @@ build_script:
 test_script:
 - npm run test
 - ps: .\setup-e2e-tests.ps1
+- ps: .\run-e2e-tests.ps1
 
 artifacts:
 - path: 'pkg/*.nupkg'

--- a/setup-e2e-tests.ps1
+++ b/setup-e2e-tests.ps1
@@ -52,20 +52,3 @@ cd "$currDir\test\end-to-end\testFunctionApp"
 }
 StopOnFailedExecution
 cd $currDir
-
-Write-Host "Starting functions host..."
-$proc = start-process -NoNewWindow -PassThru -filepath "$currDir\Azure.Functions.Cli\func.exe" -WorkingDirectory "$currDir\test\end-to-end\testFunctionApp" -ArgumentList "host start" -RedirectStandardOutput "output.txt"
-Start-Sleep -s 30
-
-Write-Host "Running E2E tests..."
-./run-e2e-tests.ps1
-
-Write-Host "Closing process..."
-Stop-Process -Id $proc.Id -Erroraction Ignore 
-
-Write-Host "Host Logs:"
-$host_logs = Get-Content -Path "output.txt" -Raw
-Write-Host $host_logs
-
-StopOnFailedExecution
-Remove-Item -Path "output.txt"

--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E.csproj
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.1.1" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.2.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.2" />

--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/Constants.cs
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/Constants.cs
@@ -43,5 +43,8 @@ namespace Azure.Functions.NodeJs.Tests.E2E
                 public static string OutputName = "test-output-one-node";
             }
         }
+
+        // Xunit Fixtures and Collections
+        public const string FunctionAppCollectionName = "FunctionAppCollection";
     }
 }

--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/CosmosDBEndToEndTests.cs
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/CosmosDBEndToEndTests.cs
@@ -7,8 +7,16 @@ using Xunit;
 
 namespace Azure.Functions.NodeJs.Tests.E2E
 {
+    [Collection(Constants.FunctionAppCollectionName)]
     public class CosmosDBEndToEndTests 
     {
+        private readonly FunctionAppFixture _fixture;
+
+        public CosmosDBEndToEndTests(FunctionAppFixture fixture)
+        {
+            this._fixture = fixture;
+        }
+
         [Fact]
         public async Task CosmosDBTriggerAndOutput_Succeeds()
         {

--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/EventHubsEndToEndTests.cs
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/EventHubsEndToEndTests.cs
@@ -10,8 +10,16 @@ using Xunit;
 
 namespace Azure.Functions.NodeJs.Tests.E2E
 {
+    [Collection(Constants.FunctionAppCollectionName)]
     public class EventHubsEndToEndTests 
     {
+        private readonly FunctionAppFixture _fixture;
+
+        public EventHubsEndToEndTests(FunctionAppFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
         [Fact]
         public async Task EventHubTriggerAndOutputJSON_Succeeds()
         {

--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/Fixtures/FixtureHelpers.cs
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/Fixtures/FixtureHelpers.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace Azure.Functions.NodeJs.Tests.E2E
+{
+    public static class FixtureHelpers
+    {
+        public static Process GetFuncHostProcess(bool enableAuth = false)
+        {
+            var funcProcess = new Process();
+            var rootDir = Path.GetFullPath(@"..\..\..\..\..\..\..");
+
+            funcProcess.StartInfo.UseShellExecute = false;
+            funcProcess.StartInfo.CreateNoWindow = true;
+            funcProcess.StartInfo.WorkingDirectory = Path.Combine(rootDir, @"test\end-to-end\testFunctionApp");
+            funcProcess.StartInfo.FileName = Path.Combine(rootDir, @"Azure.Functions.Cli\func.exe");
+            funcProcess.StartInfo.ArgumentList.Add("start");
+            if (enableAuth)
+            {
+                funcProcess.StartInfo.ArgumentList.Add("--enableAuth");
+            }
+
+            return funcProcess;
+        }
+
+        public static void KillExistingFuncHosts()
+        {
+            foreach (var func in Process.GetProcessesByName("func"))
+            {
+                func.Kill();
+            }
+        }
+    }
+}

--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/Fixtures/FunctionAppFixture.cs
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/Fixtures/FunctionAppFixture.cs
@@ -1,0 +1,74 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Azure.Functions.NodeJs.Tests.E2E
+{
+    public class FunctionAppFixture : IDisposable
+    {
+        private readonly ILogger _logger;
+        private bool _disposed;
+        private Process _funcProcess;
+
+        public FunctionAppFixture()
+        {
+            // initialize logging
+#pragma warning disable CS0618 // Type or member is obsolete
+            ILoggerFactory loggerFactory = new LoggerFactory().AddConsole();
+#pragma warning restore CS0618 // Type or member is obsolete
+            _logger = loggerFactory.CreateLogger<FunctionAppFixture>();
+
+            // start host via CLI if testing locally
+            if (Constants.FunctionsHostUrl.Contains("localhost"))
+            {
+                // kill existing func processes
+                _logger.LogInformation("Shutting down any running functions hosts..");
+                FixtureHelpers.KillExistingFuncHosts();
+
+                // start functions process
+                _logger.LogInformation($"Starting functions host for {Constants.FunctionAppCollectionName}..");
+                _funcProcess = FixtureHelpers.GetFuncHostProcess();
+                _funcProcess.Start();
+
+                Thread.Sleep(TimeSpan.FromSeconds(30));
+            }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _logger.LogInformation("FunctionAppFixture disposing.");
+
+                    if (_funcProcess != null)
+                    {
+                        _logger.LogInformation($"Shutting down functions host for {Constants.FunctionAppCollectionName}");
+                        _funcProcess.Kill();
+                        _funcProcess.Dispose();
+                    }
+                }
+
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+    }
+
+    [CollectionDefinition(Constants.FunctionAppCollectionName)]
+    public class FunctionAppCollection : ICollectionFixture<FunctionAppFixture>
+    {
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.
+    }
+}

--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/HttpEndToEndTests.cs
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/HttpEndToEndTests.cs
@@ -7,8 +7,16 @@ using Xunit;
 
 namespace Azure.Functions.NodeJs.Tests.E2E
 {
+    [Collection(Constants.FunctionAppCollectionName)]
     public class HttpEndToEndTests 
     {
+        private readonly FunctionAppFixture _fixture;
+
+        public HttpEndToEndTests(FunctionAppFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
         [Theory]
         [InlineData("HttpTrigger", "?name=Test", HttpStatusCode.OK, "Hello Test")]
         [InlineData("HttpTrigger", "?name=John&lastName=Doe", HttpStatusCode.OK, "Hello John")]

--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/StorageEndToEndTests.cs
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/StorageEndToEndTests.cs
@@ -7,8 +7,16 @@ using Xunit;
 
 namespace Azure.Functions.NodeJs.Tests.E2E
 {
+    [Collection(Constants.FunctionAppCollectionName)]
     public class StorageEndToEndTests 
     {
+        private FunctionAppFixture _fixture;
+
+        public StorageEndToEndTests(FunctionAppFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
         [Fact]
         public async Task QueueTriggerAndOutput_Succeeds()
         {


### PR DESCRIPTION
Per offline discussion, this refactoring:

- removes the need to write test output to .txt file
- isolates test environments, useful for tests that require specific settings