### PR TITLE
add `null` for the error in `context.done(err,result)`

### DIFF
--- a/types/public/Interfaces.d.ts
+++ b/types/public/Interfaces.d.ts
@@ -55,7 +55,7 @@ export interface Context {
      * @param result An object containing output binding data. `result` will be passed to JSON.stringify unless it is
      *  a string, Buffer, ArrayBufferView, or number.
      */
-    done(err?: Error | string, result?: any): void;
+    done(err?: Error | string | null, result?: any): void;
     /**
      * HTTP request object. Provided to your function when using HTTP Bindings.
      */


### PR DESCRIPTION
Based on JavaScript documentation, `null` is passed if there is no error. Although an empty string works, technicall null should be valid: https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-node#contextdone-method

Should the docs be changed to be providing an empty string or is `null` the recommended approach for TypeScript? Both options work in JavaScript