### PR TITLE
context.done should accept null as first param

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ The nuget package can be deployed from the appveyor job at: https://ci.appveyor.
 ## Contributing
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+### Contributing to TypeScript type definitions
+
+`types/public/Interfaces.d.ts` is a generated file from `src/public/Interfaces.ts`. If you want to add a change to `Interfaces.d.ts`, please make the change first to `Interfaces.ts` and then `npm run build` to generate the appropriate type definitions. Any additional type definition tests should go in `test/InterfacesTest.ts`.

--- a/src/public/Interfaces.ts
+++ b/src/public/Interfaces.ts
@@ -52,7 +52,7 @@ export interface Context {
      * @param result An object containing output binding data. `result` will be passed to JSON.stringify unless it is
      *  a string, Buffer, ArrayBufferView, or number.
      */
-    done(err?: Error | string, result?: any): void;
+    done(err?: Error | string | null, result?: any): void;
     /**
      * HTTP request object. Provided to your function when using HTTP Bindings.
      */

--- a/test/InterfacesTest.ts
+++ b/test/InterfacesTest.ts
@@ -51,4 +51,9 @@ const runHttpWithQueue: AzureFunction = async function (context: Context, req: H
     return;
 }
 
-export { runHttp, runHttpReturn, runServiceBus, runFunction, runHttpWithQueue };
+const returnWithContextDone: AzureFunction = function (context: Context, req: HttpRequest) {
+    context.log.info("Writing to queue");
+    context.done(null, { myOutput: { text: 'hello there, world', noNumber: true }});
+}
+
+export { runHttp, runHttpReturn, runServiceBus, runFunction, runHttpWithQueue, returnWithContextDone };

--- a/types/public/Interfaces.d.ts
+++ b/types/public/Interfaces.d.ts
@@ -55,7 +55,7 @@ export interface Context {
      * @param result An object containing output binding data. `result` will be passed to JSON.stringify unless it is
      *  a string, Buffer, ArrayBufferView, or number.
      */
-    done(err?: Error | string, result?: any): void;
+    done(err?: Error | string | null, result?: any): void;
     /**
      * HTTP request object. Provided to your function when using HTTP Bindings.
      */

--- a/types/public/package.json
+++ b/types/public/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/functions",
-  "version": "1.0.2-beta1",
+  "version": "1.0.2-beta2",
   "description": "Azure Functions types for Typescript",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added contribution notes for TS too.

Expands on work done here (thanks @michael-watson !) https://github.com/Azure/azure-functions-nodejs-worker/pull/194