### PR TITLE
Temporarily disable E2E tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 variables: {
-  WORKER_VERSION: '1.1.0',
+  WORKER_VERSION: '1.0.3',
   NODE_LOWER_LTS: '8.x',
   NODE_HIGHER_LTS: '10.x'
 }
@@ -46,6 +46,7 @@ jobs:
     displayName: 'npm test'
 
 - job: E2ETests
+  condition: false
   strategy:
     maxParallel: 1
     matrix:
@@ -76,7 +77,7 @@ jobs:
     displayName: 'Run E2E Tests'
   
 - job: BuildArtifacts  
-  condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
   pool:
     vmImage: 'vs2017-win2016'
   steps:


### PR DESCRIPTION
Bug in core tools, after v2.7.1382 Commit hash: f9f194023de4a35f29e07ff7d4c150e6650193f3
causes extension bundle download to fail.