### PR TITLE
Test v2.x branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,7 @@ name: $(WORKER_VERSION)-$(Date:yyyyMMdd)$(Rev:.r)
 trigger:
 - master
 - dev
+- v2.x
 
 jobs:
 - job: UnitTests


### PR DESCRIPTION
This change adds v2,x as a branch to test. v2.x branch currently (see changes [here](https://github.com/Azure/azure-functions-nodejs-worker/compare/v2.x?expand=1)):
- removes Node.js v8
- changes worker version to 2.0.0
- introduces "v2Compatible" flag which reverts everything [breaking]
- [breaking] does not duplicate http payload in `context.bindingData`
- [breaking] fixes #228 (handles http output correctly on context.(null, { body: "hello" });

TODO:
- remove Node.js v10 support?
   - potentially leverage Node.js v12 features
- [breaking] fix camelCase of timer trigger object: #188 
   - potentially add to .proto
- [breaking] consider removing context.req and context.res objects: #204
- [breaking] in host and worker, make sure http payload "as raw" as possible
- explore options for bugs with protobuf.js and windows (Issue 1303, Issue 1275)
    - protoc or just default Linux and accept Windows bugs? Probably document windows bugs