### PR TITLE
Add HttpResponse interface

### DIFF
--- a/types/public/Interfaces.d.ts
+++ b/types/public/Interfaces.d.ts
@@ -111,6 +111,23 @@ export interface HttpRequest {
     rawBody?: any;
 }
 /**
+* HTTP response object. Provided to your function when using HTTP Bindings.
+*/
+export interface HttpResponse {
+    /**
+     * HTTP response status code
+     */
+    status: number;
+    /**
+     * HTTP response body.
+     */
+    body: unknown;
+    /**
+     * HTTP response headers.
+     */
+    headers?: object;
+}
+/**
  * Possible values for an HTTP request method.
  */
 export declare type HttpMethod = "GET" | "POST" | "DELETE" | "HEAD" | "PATCH" | "PUT" | "OPTIONS" | "TRACE" | "CONNECT";


### PR DESCRIPTION
copied from https://github.com/Azure/azure-functions-durable-js/blob/master/src/ihttpresponse.ts

This is useful for HttpTriggers.

example usage:
```ts
import { AzureFunction, Context, HttpRequest, HttpResponse } from '@azure/functions'

export interface OutputBinding {
  res: HttpResponse // <--- usage
}

const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<OutputBinding> {
  const output: OutputBinding = {
      res: { status: 400, body: { message: 'bad request' } }
   }
   return output
}

export default httpTrigger
```