### PR TITLE
Fix durable-js in Azure Functions V3

### DIFF
--- a/src/FunctionInfo.ts
+++ b/src/FunctionInfo.ts
@@ -13,7 +13,7 @@ export class FunctionInfo {
     [key: string]: rpc.IBindingInfo & { converter: (any) => rpc.ITypedData }
   };
   public httpOutputName: string;
-  public isHttp: boolean;
+  public hasHttpTrigger: boolean;
 
   constructor(metadata: rpc.IRpcFunctionMetadata) {
     this.name = <string>metadata.name;
@@ -21,7 +21,7 @@ export class FunctionInfo {
     this.bindings = {};
     this.outputBindings = {};
     this.httpOutputName = "";
-    this.isHttp = false;
+    this.hasHttpTrigger = false;
 
     if (metadata.bindings) {
       let bindings = this.bindings = metadata.bindings;
@@ -39,10 +39,10 @@ export class FunctionInfo {
           }
         });
       
-      this.isHttp = Object.keys(bindings)
+      this.hasHttpTrigger = Object.keys(bindings)
         .filter(name => {
           let type = bindings[name].type;
-          return type && type.toLowerCase() == 'httptrigger';
+          return type && type.toLowerCase() === 'httptrigger';
         })
         .length > 0;
     }

--- a/src/FunctionInfo.ts
+++ b/src/FunctionInfo.ts
@@ -42,7 +42,7 @@ export class FunctionInfo {
       this.isHttp = Object.keys(bindings)
         .filter(name => {
           let type = bindings[name].type;
-          return type && type.toLowerCase() == 'httpTrigger';
+          return type && type.toLowerCase() == 'httptrigger';
         })
         .length > 0;
     }

--- a/src/FunctionInfo.ts
+++ b/src/FunctionInfo.ts
@@ -13,6 +13,7 @@ export class FunctionInfo {
     [key: string]: rpc.IBindingInfo & { converter: (any) => rpc.ITypedData }
   };
   public httpOutputName: string;
+  public isHttp: boolean;
 
   constructor(metadata: rpc.IRpcFunctionMetadata) {
     this.name = <string>metadata.name;
@@ -20,6 +21,7 @@ export class FunctionInfo {
     this.bindings = {};
     this.outputBindings = {};
     this.httpOutputName = "";
+    this.isHttp = false;
 
     if (metadata.bindings) {
       let bindings = this.bindings = metadata.bindings;
@@ -28,13 +30,21 @@ export class FunctionInfo {
       Object.keys(bindings)
         .filter(name => bindings[name].direction !== rpc.BindingInfo.Direction.in)
         .forEach(name => {
-          if (bindings[name].type === 'http') {
+          let type = bindings[name].type;
+          if (type && type.toLowerCase() === 'http') {
             this.httpOutputName = name;
             this.outputBindings[name] = Object.assign(bindings[name], { converter: toRpcHttp });
           } else {
             this.outputBindings[name] = Object.assign(bindings[name], { converter: toTypedData });
           }
         });
+      
+      this.isHttp = Object.keys(bindings)
+        .filter(name => {
+          let type = bindings[name].type;
+          return type && type.toLowerCase() == 'httpTrigger';
+        })
+        .length > 0;
     }
   }
 

--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -209,6 +209,11 @@ export class WorkerChannel implements IWorkerChannel {
                     data: info.outputBindings[key].converter(result.return[key])
                   });
               }
+              // returned value does not match any output bindings - pass it along
+              // this specifically is to allow the durable binding to work
+              if (!response.returnValue && response.outputData.length == 0) {
+                response.returnValue = toTypedData(result.return);
+              }
             }
           }
           // Set results from context.bindings

--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -211,7 +211,7 @@ export class WorkerChannel implements IWorkerChannel {
               }
               // returned value does not match any output bindings (named or $return)
               // if not http, pass along value
-              if (!response.returnValue && response.outputData.length == 0 && !info.isHttp) {
+              if (!response.returnValue && response.outputData.length == 0 && !info.hasHttpTrigger) {
                 response.returnValue = toTypedData(result.return);
               }
             }

--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -201,7 +201,7 @@ export class WorkerChannel implements IWorkerChannel {
               if (returnBinding) {
                 response.returnValue = returnBinding.converter(result.return);
               // $return binding is not found: read result as object of outputs
-              } else if (result.return) {
+              } else {
                 response.outputData = Object.keys(info.outputBindings)
                   .filter(key => result.return[key] !== undefined)
                   .map(key => <rpc.IParameterBinding>{

--- a/test/FunctionInfoTests.ts
+++ b/test/FunctionInfoTests.ts
@@ -11,7 +11,7 @@ describe('FunctionInfo', () => {
     let metadata: rpc.IRpcFunctionMetadata = {
         bindings: {
             req: {
-                type: "http",
+                type: "httpTrigger",
                 direction: 0,
                 dataType: 1
             },
@@ -25,6 +25,22 @@ describe('FunctionInfo', () => {
     
     let funcInfo = new FunctionInfo(metadata);
     expect(funcInfo.getReturnBinding().converter.name).to.equal("toRpcHttp");
+  });
+
+  it('"isHttp" is true for http', () => {
+    let metadata: rpc.IRpcFunctionMetadata = {
+        bindings: {
+            req: {
+                type: "httpTrigger",
+                direction: 0,
+                dataType: 1
+            }
+        }
+    };
+    
+    let funcInfo = new FunctionInfo(metadata);
+    expect(funcInfo.getReturnBinding()).to.be.undefined;
+    expect(funcInfo.isHttp).to.be.true;
   });
 
   it('gets $return output binding converter for TypedData', () => {

--- a/test/FunctionInfoTests.ts
+++ b/test/FunctionInfoTests.ts
@@ -27,7 +27,7 @@ describe('FunctionInfo', () => {
     expect(funcInfo.getReturnBinding().converter.name).to.equal("toRpcHttp");
   });
 
-  it('"isHttp" is true for http', () => {
+  it('"hasHttpTrigger" is true for http', () => {
     let metadata: rpc.IRpcFunctionMetadata = {
         bindings: {
             req: {
@@ -40,7 +40,7 @@ describe('FunctionInfo', () => {
     
     let funcInfo = new FunctionInfo(metadata);
     expect(funcInfo.getReturnBinding()).to.be.undefined;
-    expect(funcInfo.isHttp).to.be.true;
+    expect(funcInfo.hasHttpTrigger).to.be.true;
   });
 
   it('gets $return output binding converter for TypedData', () => {

--- a/test/WorkerChannelTests.ts
+++ b/test/WorkerChannelTests.ts
@@ -77,6 +77,11 @@ describe('WorkerChannel', () => {
       overriddenQueueOutput: queueOutputBinding
     } 
   };
+  const inputOnlyBinding = {
+    bindings: {
+      test: httpInputBinding
+    }
+  };
 
   beforeEach(() => {
     stream = new TestEventStream();
@@ -294,10 +299,7 @@ describe('WorkerChannel', () => {
 
   it ('invokes function in V2 compat mode', () => {
     loader.getFunc.returns((context) => context.done());
-    loader.getInfo.returns({
-      name: 'test',
-      outputBindings: {}
-    })
+    loader.getInfo.returns(new FunctionInfo(inputOnlyBinding));
 
     var actualInvocationRequest: rpc.IInvocationRequest = <rpc.IInvocationRequest> {
       functionId: 'id',
@@ -336,10 +338,7 @@ describe('WorkerChannel', () => {
 
   it ('invokes function', () => {
     loader.getFunc.returns((context) => context.done());
-    loader.getInfo.returns({
-      name: 'test',
-      outputBindings: {}
-    })
+    loader.getInfo.returns(new FunctionInfo(inputOnlyBinding));
 
     var actualInvocationRequest: rpc.IInvocationRequest = <rpc.IInvocationRequest> {
       functionId: 'id',

--- a/test/WorkerChannelTests.ts
+++ b/test/WorkerChannelTests.ts
@@ -42,8 +42,13 @@ describe('WorkerChannel', () => {
         }
     } 
   };
+  const orchestrationTriggerBinding = {
+    type: "orchestrationtrigger",
+    direction: 1,
+    dataType: 1
+  };
   const httpInputBinding = { 
-    type: "http",
+    type: "httpTrigger",
     direction: 0,
     dataType: 1
   };
@@ -77,9 +82,9 @@ describe('WorkerChannel', () => {
       overriddenQueueOutput: queueOutputBinding
     } 
   };
-  const inputOnlyBinding = {
+  const orchestratorBinding = {
     bindings: {
-      test: httpInputBinding
+      test: orchestrationTriggerBinding
     }
   };
 
@@ -299,7 +304,7 @@ describe('WorkerChannel', () => {
 
   it ('invokes function in V2 compat mode', () => {
     loader.getFunc.returns((context) => context.done());
-    loader.getInfo.returns(new FunctionInfo(inputOnlyBinding));
+    loader.getInfo.returns(new FunctionInfo(orchestratorBinding));
 
     var actualInvocationRequest: rpc.IInvocationRequest = <rpc.IInvocationRequest> {
       functionId: 'id',
@@ -338,7 +343,7 @@ describe('WorkerChannel', () => {
 
   it ('invokes function', () => {
     loader.getFunc.returns((context) => context.done());
-    loader.getInfo.returns(new FunctionInfo(inputOnlyBinding));
+    loader.getInfo.returns(new FunctionInfo(orchestratorBinding));
 
     var actualInvocationRequest: rpc.IInvocationRequest = <rpc.IInvocationRequest> {
       functionId: 'id',
@@ -402,6 +407,62 @@ describe('WorkerChannel', () => {
             statusCode: undefined
           }
         }
+      }
+    });
+  });
+
+  it ('returns returned output if not http', () => {
+    loader.getFunc.returns((context) => context.done(null, ["hello, seattle!", "hello, tokyo!"]));
+    loader.getInfo.returns(new FunctionInfo(orchestratorBinding));
+
+    var actualInvocationRequest: rpc.IInvocationRequest = <rpc.IInvocationRequest> {
+      functionId: 'id',
+      invocationId: '1',
+      inputData: [],
+      triggerMetadata: getTriggerDataMock(),
+    };
+
+    stream.addTestMessage({
+      invocationRequest: actualInvocationRequest
+    });
+
+    sinon.assert.calledWithMatch(stream.written, <rpc.IStreamingMessage> {
+      invocationResponse: {
+        invocationId: '1',
+        result:  {
+          status: rpc.StatusResult.Status.Success
+        },
+        outputData: [],
+        returnValue: { 
+          json: "[\"hello, seattle!\",\"hello, tokyo!\"]"
+        }
+      }
+    });
+  });
+
+  it ('returned output is ignored if http', () => {
+    loader.getFunc.returns((context) => context.done(null, ["hello, seattle!", "hello, tokyo!"]));
+    loader.getInfo.returns(new FunctionInfo(httpResBinding));
+
+    var actualInvocationRequest: rpc.IInvocationRequest = <rpc.IInvocationRequest> {
+      functionId: 'id',
+      invocationId: '1',
+      inputData: [],
+      triggerMetadata: getTriggerDataMock(),
+    };
+
+    stream.addTestMessage({
+      invocationRequest: actualInvocationRequest
+    });
+
+    sinon.assert.calledWithMatch(stream.written, <rpc.IStreamingMessage> {
+      invocationResponse: {
+        invocationId: '1',
+        result:  {
+          status: rpc.StatusResult.Status.Success
+        },
+        outputData: [],
+        returnValue: undefined
       }
     });
   });


### PR DESCRIPTION
An orchestration trigger binding doesn't have a corresponding, explicit output, but does expect to be returned. This change returns that information in JSON form.