### PR TITLE
Node.js version recommendation for V2

### DIFF
--- a/src/nodejsWorker.ts
+++ b/src/nodejsWorker.ts
@@ -17,10 +17,10 @@ function validateNodeVersion(version) {
             message = "Could not parse Node.js version: '" + version + "'";
         // Unsupported version note: Documentation about Node's stable versions here: https://github.com/nodejs/Release#release-plan and an explanation here: https://medium.com/swlh/understanding-how-node-releases-work-in-2018-6fd356816db4
         } else if (supportedVersions.indexOf(major) < 0) {
-            message = "Incompatible Node.js version. The version you are using is "
-                + version +
-                ", but the runtime requires an LTS-covered major version. LTS-covered versions have an even major version number (8.x, 10.x, etc.) as per https://github.com/nodejs/Release#release-plan. "
-                + "For deployed code, change WEBSITE_NODE_DEFAULT_VERSION to '~10' in App Settings. Locally, install or switch to a supported node version (make sure to quit and restart your code editor to pick up the changes).";
+            message = "Incompatible Node.js version"
+            + " (" + version + ")."
+            + " The version of the Azure Functions runtime you are using (v2) supports Node.js v8.x and v10.x."
+            + " Refer to our documentation to see the Node.js versions supported by each version of Azure Functions: https://aka.ms/functions-node-versions";
         }
         // Log a warning that v12 is not fully supported
         if (major === "v12")

--- a/src/nodejsWorker.ts
+++ b/src/nodejsWorker.ts
@@ -23,8 +23,7 @@ function validateNodeVersion(version) {
             + " Refer to our documentation to see the Node.js versions supported by each version of Azure Functions: https://aka.ms/functions-node-versions";
         }
         // Log a warning that v12 is not fully supported
-        if (major === "v12")
-        {
+        if (major === "v12") {
             console.warn(warnPrefix + "The Node.js version you are using (" + version + ") is not fully supported by Azure Functions V2. We recommend using one the following major versions: 8, 10.");
         }
         


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-functions-core-tools/issues/1988 for Functions V2

Example output:
```
[error] Incompatible Node.js version (v6.11.1). The version of the Azure Functions runtime you are using (v2) supports Node.js v8.x and v10.x. Refer to our documentation to see the Node.js versions supported by each version of Azure Functions: https://aka.ms/functions-node-versions
```