### PR TITLE
Ignore proxy functions in node worker v2.x

### DIFF
--- a/src/FunctionLoader.ts
+++ b/src/FunctionLoader.ts
@@ -17,6 +17,9 @@ export class FunctionLoader implements IFunctionLoader {
     }} = {};
 
     load(functionId: string, metadata: rpc.IRpcFunctionMetadata): void {
+      if (metadata.isProxy === true) {
+          return;
+      }
       let scriptFilePath = <string>(metadata && metadata.scriptFile);
       let script = require(scriptFilePath);
       let entryPoint = <string>(metadata && metadata.entryPoint);

--- a/test/FunctionLoaderTests.ts
+++ b/test/FunctionLoaderTests.ts
@@ -36,6 +36,17 @@ describe('FunctionLoader', () => {
      }).to.throw("Unable to determine function entry point. If multiple functions are exported, you must indicate the entry point, either by naming it 'run' or 'index', or by naming it explicitly via the 'entryPoint' metadata property.");
   });
   
+  it ('does not load proxy function', () => {
+    mock('test', {});
+    loader.load('functionId', <rpc.IRpcFunctionMetadata> {
+        isProxy: true
+    });
+      
+    expect(() => {
+      loader.getFunc('functionId');
+    }).to.throw("Function code for 'functionId' is not loaded and cannot be invoked.");
+  });
+
   it ('throws unable to determine function entry point with entryPoint name', () => {
     mock('test', { test: {} });
     let entryPoint = 'wrongEntryPoint'


### PR DESCRIPTION
* do not load proxy functions

* check against true

v2 version: https://github.com/Azure/azure-functions-nodejs-worker/pull/299/files