### PR TITLE
Fix to load prototype 'run' or 'index' as entry point if exported obj…

### DIFF
--- a/src/FunctionLoader.ts
+++ b/src/FunctionLoader.ts
@@ -55,15 +55,15 @@ export class FunctionLoader implements IFunctionLoader {
 function getEntryPoint(f: any, entryPoint?: string): Function {
     if (isObject(f)) {
         var obj = f;
+        let keys = Object.keys(f);
         if (entryPoint) {
             // the module exports multiple functions
             // and an explicit entry point was named
             f = f[entryPoint];
         }
-        else if (Object.keys(f).length === 1) {
+        else if (keys.length === 1 && isFunction(f[keys[0]])) {
             // a single named function was exported
-            var name = Object.keys(f)[0];
-            f = f[name];
+            f = f[keys[0]];
         }
         else {
             // finally, see if there is an exported function named

--- a/test/FunctionLoaderTests.ts
+++ b/test/FunctionLoaderTests.ts
@@ -69,6 +69,77 @@ describe('FunctionLoader', () => {
     }).to.throw("The resolved entry point is not a function and cannot be invoked by the functions runtime. Make sure the function has been correctly exported.");
   });
 
+  it ('allows to use a single named function in the exported object', () => {
+    var FuncObject =  (function () {
+      function FuncObject(this: any) {
+        this.testFunc = function() {
+          return 'testFunc';
+        };
+      };
+      FuncObject.prototype.run = function () {
+          return 'prototype';
+      };
+      return FuncObject;
+    }());
+
+    mock('test', new FuncObject());
+
+    loader.load('functionId', <rpc.IRpcFunctionMetadata> {
+      scriptFile: 'test'
+    });
+
+    var userFunction = loader.getFunc('functionId');
+    var result = userFunction();
+
+    expect(result).to.eql('testFunc');
+  });
+
+  it ("allows to use prototype function named 'run' if the exported object has no functions", () => {
+    var FuncObject = /** @class */ (function () {
+      function FuncObject(this: any) {
+          this.prop = true; // this object has one enumerable property, which is not a function
+      };
+      FuncObject.prototype.run = function () {
+          return 'ret';
+      };
+      return FuncObject;
+    }());
+
+    mock('test', new FuncObject());
+
+    loader.load('functionId', <rpc.IRpcFunctionMetadata> {
+      scriptFile: 'test'
+    });
+
+    var userFunction = loader.getFunc('functionId');
+    var result = userFunction();
+
+    expect(result).to.eql('ret');
+  });
+
+  it ("allows to use prototype function named 'index' if the exported object has no functions", () => {
+    var FuncObject = /** @class */ (function () {
+      function FuncObject(this: any) {
+          this.prop = true; // this object has one enumerable property, which is not a function
+      };
+      FuncObject.prototype.index = function () {
+          return 'ret';
+      };
+      return FuncObject;
+    }());
+
+    mock('test', new FuncObject());
+
+    loader.load('functionId', <rpc.IRpcFunctionMetadata> {
+      scriptFile: 'test'
+    });
+
+    var userFunction = loader.getFunc('functionId');
+    var result = userFunction();
+
+    expect(result).to.eql('ret');
+  });
+
   it ('allows use of \'this\' in loaded user function', () => {
     var FuncObject = /** @class */ (function () {
       function FuncObject(this: any) {


### PR DESCRIPTION
resolve #315 

Fix condition to consider whether the single property is function.  