### PR TITLE
[WIP] Avoid parsing numeric string to number

### DIFF
--- a/src/converters/RpcConverters.ts
+++ b/src/converters/RpcConverters.ts
@@ -20,7 +20,7 @@ export function fromTypedData(typedData?: rpc.ITypedData, convertStringToJson: b
     if (str !== undefined) {
         if (convertStringToJson) {
             try {
-                if (str != null) {
+                if (str != null && isJsonFormedStr(str)) {
                     str = JSON.parse(str);
                 }
             } catch (err) { }
@@ -181,4 +181,9 @@ export function toNullableTimestamp(dateTime: Date | number | undefined, propert
         }
     }
     return undefined;
+}
+
+function isJsonFormedStr(str: string): boolean {
+    const maybeJsonFormedStrRegex = new RegExp(/^\{.*\}$|^\[.*\]$/sm);
+    return maybeJsonFormedStrRegex.test(str);
 }

--- a/test/RpcConvertersTests.ts
+++ b/test/RpcConvertersTests.ts
@@ -1,4 +1,4 @@
-import { toNullableBool, toNullableString, toNullableDouble, toNullableTimestamp, fromRpcTraceContext } from '../src/converters';
+import { toNullableBool, toNullableString, toNullableDouble, toNullableTimestamp, fromRpcTraceContext, fromTypedData } from '../src/converters';
 import { expect } from 'chai';
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
 import 'mocha';
@@ -161,5 +161,10 @@ describe('Rpc Converters', () => {
   it('does not convert undefined to NullableTimestamp', () => {
     let nullable = toNullableTimestamp(undefined, "test");
     expect(nullable && nullable.value).to.be.undefined;
+  });
+
+  it('numeric-string keeps string type', () => {
+    let numericString = fromTypedData({ string: '12345678901234567890' });
+    expect(numericString).to.equal('12345678901234567890');
   });
 })


### PR DESCRIPTION
fix: https://github.com/Azure/azure-functions-durable-js/issues/215

As described in Issue above, if you pass a string of numbers as the binding value, they will be treated as numbers in the function.
That process is taking place ...
https://github.com/Azure/azure-functions-nodejs-worker/blob/ac130db668086b6ef75a2765ae3a69c4dcda4081/src/converters/RpcConverters.ts#L24

If this process fails, the `str` passed in is used as the return value of this function, or the `typedData` passed in the caller is treated as the return value.

### problem

[`JSON.parse` ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse ) can parse Objects, Arrays and Numbers.
ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON

In Node.js environment we cannot treat large number(such as 12345678901234567890) correctly with `number` type, so we sometimes uses it stringified-number (ex: `'12345678901234567890'`).

In this product, `JSON.parse` processes the passed str without exception, so any stringified-numbers that we want to treat as strings will also be treated as numbers.


### solution

Test that the `str` passed in the regular expression is in a valid format as JSON. (does not support JSON completely...)

### does this change has breaking-channge?

Yes

And now, this change does not fully-supported JSON syntax...
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON#Full_JSON_syntax:~:text=Full%20JSON%20syntax,-The

Numbers, null, boolean will be affected.

