### PR TITLE
feature: add before/after InvocationRequest hooks

### DIFF
--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -57,4 +57,6 @@ export function startNodeWorker(args) {
   process.on('exit', code => {
     systemLog(`Worker ${workerId} exited with code ${code}`);
   });
+  
+  return workerChannel;
 }

--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -57,6 +57,4 @@ export function startNodeWorker(args) {
   process.on('exit', code => {
     systemLog(`Worker ${workerId} exited with code ${code}`);
   });
-  
-  return workerChannel;
 }


### PR DESCRIPTION
Adds two `InvocationRequest` hooks to `WorkerChannel` to enable context correlation and node.js worker APM instrumentation. Sample use case for Azure Monitor node.js SDK.

- `invocationRequestBefore`: `(context, userFunction) => contextWrappedUserFunction`
- `invocationRequestAfter`: `() => void`

> note: `workerChannel` would need to be passed to app insights in some way, i.e. in `nodejsWorker.ts`:
```ts
if (shouldSetupAppInsightsFunctionsIntegration) {
  require("/path/to/applicationinsights/agent/functions")
    .setupFunctionsInvocationHooks(workerChannel);
}
```

In App Insights SDK, `setupFunctionsInvocationHooks` would be defined:
```ts
workerChannel.invocationRequestBefore = (context, userFunction) => {
    // Map Functions context to AppInsights context
    const correlationContext = appInsights.startOperation(context, "Functions.JavaScript.Trigger");

    // Wrap the Function runtime with correlationContext
    return appInsights.wrapWithCorrelationContext(userFunction, correlationContext);
}

workerChannel.invocationRequestAfter = () => {
    // Do any extra cleanup or flushing here
    appInsights.defaultClient.flush(); // can be async or sync
}
```