### PR TITLE
Adding ability to use .mjs files for Node.js 14 (preview)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ jobs:
     inputs:
       versionSpec: $(NODE_VERSION)
     displayName: 'Install Node.js for test'
-  - script: npm install request
+  - script: npm install -g request
     displayName: 'Workaround to https://github.com/grpc/grpc-node/issues/922'
   - script: npm install
     displayName: 'npm install'
@@ -92,7 +92,7 @@ jobs:
     inputs:
       versionSpec: $(NODE_VERSION)
     displayName: 'Install Node.js for test'
-  - script: npm install request
+  - script: npm install -g request
     displayName: 'Workaround to https://github.com/grpc/grpc-node/issues/922'
   - script: npm install
     displayName: 'npm install'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,6 +110,7 @@ jobs:
       AzureWebJobsCosmosDBConnectionString: $(AzureWebJobsCosmosDBConnectionString)
       FUNCTIONS_WORKER_RUNTIME: 'node'
       languageWorkers:node:workerDirectory: $(System.DefaultWorkingDirectory)
+      nodeVersion: $(NODE_VERSION)
   - task: PublishTestResults@2
     condition: always()
     inputs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -675,6 +675,15 @@
         "type-detect": "^4.0.5"
       }
     },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -2966,7 +2975,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         },
         "ms": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/node": "^8.0.0",
     "@types/sinon": "^2.3.7",
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "mocha": "^5.2.0",
     "mock-require": "^2.0.2",
     "node-abi": "2.1.1",

--- a/src/FunctionLoader.ts
+++ b/src/FunctionLoader.ts
@@ -28,7 +28,7 @@ export class FunctionLoader implements IFunctionLoader {
           // use eval so it doesn't get compiled into a require()
           script = await eval("import(scriptFilePath)");
         } else {
-            throw new InternalException(`Please use a Node.js version >= v14 to use ES Modules for '${scriptFilePath}'`);
+          throw new InternalException(`Please use a Node.js version >= v14 to use ES Modules for '${scriptFilePath}'`);
         }
       } else {
         script = require(scriptFilePath);

--- a/src/FunctionLoader.ts
+++ b/src/FunctionLoader.ts
@@ -5,7 +5,7 @@ import { FunctionInfo } from './FunctionInfo'
 import { InternalException } from "./utils/InternalException";
 
 export interface IFunctionLoader {
-  load(functionId: string, metadata: rpc.IRpcFunctionMetadata): void;
+  load(functionId: string, metadata: rpc.IRpcFunctionMetadata): Promise<void>;
   getInfo(functionId: string): FunctionInfo;
   getFunc(functionId: string): Function;
 }

--- a/src/FunctionLoader.ts
+++ b/src/FunctionLoader.ts
@@ -15,13 +15,24 @@ export class FunctionLoader implements IFunctionLoader {
         info: FunctionInfo,
         func: Function
     }} = {};
+    private allowESModules = process.version.startsWith("v14");
 
-    load(functionId: string, metadata: rpc.IRpcFunctionMetadata): void {
+    async load(functionId: string, metadata: rpc.IRpcFunctionMetadata): Promise<void> {
       if (metadata.isProxy === true) {
           return;
       }
       let scriptFilePath = <string>(metadata && metadata.scriptFile);
-      let script = require(scriptFilePath);
+      let script: any;
+      if (scriptFilePath.endsWith(".mjs")) {
+        if (this.allowESModules) {
+          // use eval so it doesn't get compiled into a require()
+          script = await eval("import(scriptFilePath)");
+        } else {
+            throw new InternalException(`Please use a Node.js version >= v14 to use ES Modules for '${scriptFilePath}'`);
+        }
+      } else {
+        script = require(scriptFilePath);
+      }
       let entryPoint = <string>(metadata && metadata.entryPoint);
       let userFunction = getEntryPoint(script, entryPoint);
       if(!isFunction(userFunction)) {

--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -170,11 +170,11 @@ export class WorkerChannel implements IWorkerChannel {
    * @param requestId gRPC message request id
    * @param msg gRPC message content
    */
-  public functionLoadRequest(requestId: string, msg: rpc.FunctionLoadRequest) {
+  public async functionLoadRequest(requestId: string, msg: rpc.FunctionLoadRequest) {
     if (msg.functionId && msg.metadata) {
       let err, errorMessage;
       try {
-        this._functionLoader.load(msg.functionId, msg.metadata);
+        await this._functionLoader.load(msg.functionId, msg.metadata);
       }
       catch(exception) {
         errorMessage = `Worker was unable to load function ${msg.metadata.name}: '${exception}'`;

--- a/test/WorkerChannelTests.ts
+++ b/test/WorkerChannelTests.ts
@@ -211,7 +211,7 @@ describe('WorkerChannel', () => {
     }
   });
 
-  it('responds to function load', () => {
+  it('responds to function load', async () => {
     stream.addTestMessage({
       requestId: 'id',
       functionLoadRequest: {  
@@ -219,6 +219,8 @@ describe('WorkerChannel', () => {
         metadata: { }
       }
     });
+    // Set slight delay 
+    await new Promise(resolve => setTimeout(resolve, 100));
     sinon.assert.calledWith(stream.written, <rpc.IStreamingMessage>{
       requestId: 'id',
       functionLoadResponse: {

--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/HttpEndToEndTests.cs
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/HttpEndToEndTests.cs
@@ -61,7 +61,8 @@ namespace Azure.Functions.NodeJs.Tests.E2E
                     Assert.Contains(expectedMessage, actualMessage);
                 }
             } else {
-                Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+                // This function will fail to load on the worker side
+                Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
             }
         }
 

--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/HttpEndToEndTests.cs
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/HttpEndToEndTests.cs
@@ -48,13 +48,12 @@ namespace Azure.Functions.NodeJs.Tests.E2E
         [InlineData("HttpTriggerESModules", "", HttpStatusCode.BadRequest, "Please pass a name on the query string or in the request body")]
         public async Task HttpTriggerESModuleTests(string functionName, string queryString, HttpStatusCode expectedStatusCode, string expectedMessage)
         {
-            var nodeVersion = Environment.GetEnvironmentVariable("nodeVersion");
-            Console.WriteLine(nodeVersion);
-            if (nodeVersion.StartsWith("v14.")) {
-                // TODO: Verify exception on 500 after https://github.com/Azure/azure-functions-host/issues/3589
-                HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, queryString);
-                string actualMessage = await response.Content.ReadAsStringAsync();
+            // TODO: Verify exception on 500 after https://github.com/Azure/azure-functions-host/issues/3589
+            HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, queryString);
+            string actualMessage = await response.Content.ReadAsStringAsync();
 
+            var nodeVersion = Environment.GetEnvironmentVariable("nodeVersion");
+            if (nodeVersion.Equals("14.x")) {
                 Assert.Equal(expectedStatusCode, response.StatusCode);
                 
                 if (!string.IsNullOrEmpty(expectedMessage)) {
@@ -62,7 +61,7 @@ namespace Azure.Functions.NodeJs.Tests.E2E
                     Assert.Contains(expectedMessage, actualMessage);
                 }
             } else {
-                Console.WriteLine("Skipping ES Module test for node version " + nodeVersion);
+                Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
             }
         }
 

--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/HttpEndToEndTests.cs
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/HttpEndToEndTests.cs
@@ -38,7 +38,7 @@ namespace Azure.Functions.NodeJs.Tests.E2E
             
             if (!string.IsNullOrEmpty(expectedMessage)) {
                 Assert.False(string.IsNullOrEmpty(actualMessage));
-                Assert.True(actualMessage.Contains(expectedMessage));
+                Assert.Contains(expectedMessage, actualMessage);
             }
         }
 
@@ -46,9 +46,9 @@ namespace Azure.Functions.NodeJs.Tests.E2E
         [InlineData("HttpTriggerESModules", "?name=Test", HttpStatusCode.OK, "Hello Test")]
         [InlineData("HttpTriggerESModules", "?name=John&lastName=Doe", HttpStatusCode.OK, "Hello John")]
         [InlineData("HttpTriggerESModules", "", HttpStatusCode.BadRequest, "Please pass a name on the query string or in the request body")]
-        public async Task HttpTriggerTests(string functionName, string queryString, HttpStatusCode expectedStatusCode, string expectedMessage)
+        public async Task HttpTriggerESModuleTests(string functionName, string queryString, HttpStatusCode expectedStatusCode, string expectedMessage)
         {
-            let nodeVersion = Environment.GetEnvironmentVariable("nodeVersion");
+            var nodeVersion = Environment.GetEnvironmentVariable("nodeVersion");
             Console.WriteLine(nodeVersion);
             if (nodeVersion.StartsWith("v14.")) {
                 // TODO: Verify exception on 500 after https://github.com/Azure/azure-functions-host/issues/3589
@@ -59,7 +59,7 @@ namespace Azure.Functions.NodeJs.Tests.E2E
                 
                 if (!string.IsNullOrEmpty(expectedMessage)) {
                     Assert.False(string.IsNullOrEmpty(actualMessage));
-                    Assert.True(actualMessage.Contains(expectedMessage));
+                    Assert.Contains(expectedMessage, actualMessage);
                 }
             } else {
                 Console.WriteLine("Skipping ES Module test for node version " + nodeVersion);

--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/HttpEndToEndTests.cs
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/HttpEndToEndTests.cs
@@ -43,6 +43,30 @@ namespace Azure.Functions.NodeJs.Tests.E2E
         }
 
         [Theory]
+        [InlineData("HttpTriggerESModules", "?name=Test", HttpStatusCode.OK, "Hello Test")]
+        [InlineData("HttpTriggerESModules", "?name=John&lastName=Doe", HttpStatusCode.OK, "Hello John")]
+        [InlineData("HttpTriggerESModules", "", HttpStatusCode.BadRequest, "Please pass a name on the query string or in the request body")]
+        public async Task HttpTriggerTests(string functionName, string queryString, HttpStatusCode expectedStatusCode, string expectedMessage)
+        {
+            let nodeVersion = Environment.GetEnvironmentVariable("nodeVersion");
+            Console.WriteLine(nodeVersion);
+            if (nodeVersion.StartsWith("v14.")) {
+                // TODO: Verify exception on 500 after https://github.com/Azure/azure-functions-host/issues/3589
+                HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, queryString);
+                string actualMessage = await response.Content.ReadAsStringAsync();
+
+                Assert.Equal(expectedStatusCode, response.StatusCode);
+                
+                if (!string.IsNullOrEmpty(expectedMessage)) {
+                    Assert.False(string.IsNullOrEmpty(actualMessage));
+                    Assert.True(actualMessage.Contains(expectedMessage));
+                }
+            } else {
+                Console.WriteLine("Skipping ES Module test for node version " + nodeVersion);
+            }
+        }
+
+        [Theory]
         [InlineData("HttpTriggerBodyAndRawBody", "{\"a\":1}", "application/json", HttpStatusCode.OK)]
         [InlineData("HttpTriggerBodyAndRawBody", "{\"a\":1, \"b\":}", "application/json", HttpStatusCode.OK)]
         [InlineData("HttpTriggerBodyAndRawBody", "{\"a\":1}", "application/octet-stream", HttpStatusCode.OK)]

--- a/test/end-to-end/testFunctionApp/HttpTriggerESModules/function.json
+++ b/test/end-to-end/testFunctionApp/HttpTriggerESModules/function.json
@@ -1,0 +1,20 @@
+{
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/test/end-to-end/testFunctionApp/HttpTriggerESModules/function.json
+++ b/test/end-to-end/testFunctionApp/HttpTriggerESModules/function.json
@@ -16,5 +16,6 @@
       "direction": "out",
       "name": "res"
     }
-  ]
+  ],
+  "scriptFile": "./index.mjs"
 }

--- a/test/end-to-end/testFunctionApp/HttpTriggerESModules/index.mjs
+++ b/test/end-to-end/testFunctionApp/HttpTriggerESModules/index.mjs
@@ -1,0 +1,16 @@
+export const httpTrigger = async function (context, req) {
+    context.log('JavaScript HTTP trigger function processed a request.');
+
+    if (req.query.name || (req.body && req.body.name)) {
+        context.res = {
+            // status: 200, /* Defaults to 200 */
+            body: "Hello " + (req.query.name || req.body.name)
+        };
+    }
+    else {
+        context.res = {
+            status: 400,
+            body: "Please pass a name on the query string or in the request body"
+        };
+    }
+};

--- a/worker.config.json
+++ b/worker.config.json
@@ -1,7 +1,7 @@
 {
     "description":{
         "language":"node",
-        "extensions":[".js"],
+        "extensions":[".js", ".mjs"],
         "defaultExecutablePath":"node",
         "defaultWorkerPath":"dist/src/nodejsWorker.js"
     }


### PR DESCRIPTION
Note that this only enables ES Modules through the `.mjs` file extension, which is 1 of 3 ways to enable ES Modules currently: https://nodejs.org/api/esm.html#esm_enabling (excludes the package.json "type" field and the --input-type flag)

If .msj is used with node.js version < 14.x, then the result will be a "500" not a "404" (same behavior if there are other issues loading a script file).

**TODO**: In host, need to update this line of code to also look for "index.mjs"
https://github.com/Azure/azure-functions-host/blob/dd062a5cc9e1f8e8bb875d3e6068b1df3865257a/src/WebJobs.Script/Host/FunctionMetadataProvider.cs#L245

**TODO:** Verify no performance regressions