### PR TITLE
feat: support optional generic for return type of `AzureFunction`

### DIFF
--- a/src/public/Interfaces.ts
+++ b/src/public/Interfaces.ts
@@ -9,7 +9,7 @@
  * @returns Output bindings (optional). If you are returning a result from a Promise (or an async function), this 
  * result will be passed to JSON.stringify unless it is a string, Buffer, ArrayBufferView, or number.
  */
-export type AzureFunction = ((context: Context, ...args: any[]) => Promise<any> | void);
+export type AzureFunction<TReturn = any> = ((context: Context, ...args: any[]) => Promise<TReturn> | void);
 
 export interface ContextBindings {
   [name: string]: any;

--- a/types/public/Interfaces.d.ts
+++ b/types/public/Interfaces.d.ts
@@ -9,7 +9,7 @@
  * @returns Output bindings (optional). If you are returning a result from a Promise (or an async function), this
  * result will be passed to JSON.stringify unless it is a string, Buffer, ArrayBufferView, or number.
  */
-export declare type AzureFunction = ((context: Context, ...args: any[]) => Promise<any> | void);
+export declare type AzureFunction<TReturn = any> = ((context: Context, ...args: any[]) => Promise<TReturn> | void);
 export interface ContextBindings {
     [name: string]: any;
 }


### PR DESCRIPTION
This lets us do:

```
export const handler: AzureFunction<FnResponse> = async (
  context,
  request: HttpRequest
) => {
```

This can be improved further by making `args` a generic too:

```
export declare type AzureFunction<TReturn = any, TArgs extends any[] = any[]> = ((context: Context, ...args: TArgs) => Promise<TReturn> | void);
```

which lets us do

```
export const handler: AzureFunction<FnResponse, [HttpRequest]> = async (
  context,
  request // has type HttpRequest
) => {
```

However, this requires higher than TypeScript 2 (maybe lower than 3.3, but the playground doesn't go lower)