### PR TITLE
Add missing originalUrl to HttpRequest interface

### DIFF
--- a/types/public/Interfaces.d.ts
+++ b/types/public/Interfaces.d.ts
@@ -95,6 +95,10 @@ export interface HttpRequest {
      */
     url: string;
     /**
+     * Raw request url
+     */
+    originalUrl: string,
+    /**
      * HTTP request headers.
      */
     headers: HttpRequestHeaders;


### PR DESCRIPTION
The `HttpRequest` interface is missing the `originalUrl` property as per the docs and runtime.

See https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=v2#request-object

| Property | Description |
| -------- | ----------- |
| *body*   | An object that contains the body of the request. |
| *headers* | An object that contains the request headers. |
| *method* | The HTTP method of the request. |
| *originalUrl* | The URL of the request. |
| *params* | An object that contains the routing parameters of the request. |
| *query* | An object that contains the query parameters. |
| *rawBody* | The body of the message as a string. |