### PR TITLE
Add HttpResponse interface

### DIFF
--- a/types/public/Interfaces.d.ts
+++ b/types/public/Interfaces.d.ts
@@ -96,6 +96,22 @@ export interface HttpResponse {
      * An HTTP cookie object has a name, value, and other cookie properties, such as maxAge or sameSite.
      */
     cookies?: Cookie[],
+    /**
+     * A helper to access headers on the response
+     */
+    get(header: string): string | undefined,
+    /**
+     * A helper to set headers on the response
+     */
+    set(header: string, value?: string): void,
+    /**
+     * A helper to set headers on the response
+     */
+    header(header: string, value?: string): void,
+    /**
+     * A helper to send the response
+     */
+    send(body: any): void,
 }
 export interface HttpRequestHeaders {
     [name: string]: string | undefined;

--- a/types/public/Interfaces.d.ts
+++ b/types/public/Interfaces.d.ts
@@ -69,9 +69,33 @@ export interface Context {
     /**
      * HTTP response object. Provided to your function when using HTTP Bindings.
      */
-    res?: {
-        [key: string]: any;
-    };
+    res?: HttpResponse;
+}
+export interface HttpResponseHeaders {
+    [name: string]: string | undefined;
+}
+export interface HttpResponse {
+    /**
+     * An object that contains the body of the response.
+     */
+    body: any,
+    /**
+     * An object that contains the response headers.
+     */
+    headers?: HttpResponseHeaders,
+    /**
+     * Indicates that formatting is skipped for the response.
+     */
+    isRaw?: boolean,
+    /**
+     * The HTTP status code of the response.
+     */
+    status?: number,
+    /**
+     * An array of HTTP cookie objects that are set in the response.
+     * An HTTP cookie object has a name, value, and other cookie properties, such as maxAge or sameSite.
+     */
+    cookies?: Cookie[],
 }
 export interface HttpRequestHeaders {
     [name: string]: string | undefined;


### PR DESCRIPTION
The `Context.res?` property is represented as an unbound map of values (`[key: string]: any`) when the shape of a the response is more specific than that.

In addition to this I've added some undocumented (but present) functions:

When logging the shape of a standard `Response` from a function execution (and when looking at the source - https://github.com/Azure/azure-functions-nodejs-worker/blob/v2.x/src/http/Response.ts) we can see that these functions do form part of the internal interface

`Response {
  headers: {},
  cookies: [],
  send: [Function: end],
  header: [Function: setHeader],
  set: [Function: setHeader],
  get: [Function: getHeader],
  _done: [Function] }`

---

see https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=v2#response-object

| Property | Description |
| -------- | ----------- |
| *body*   | An object that contains the body of the response. |
| *headers* | An object that contains the response headers. |
| *isRaw* | Indicates that formatting is skipped for the response. |
| *status* | The HTTP status code of the response. |
| *cookies* | An array of HTTP cookie objects that are set in the response. An HTTP cookie object has a `name`, `value`, and other cookie properties, such as `maxAge` or `sameSite`. |