### PR TITLE
Serialize falsy values for Durable Functions

### DIFF
--- a/src/FunctionInfo.ts
+++ b/src/FunctionInfo.ts
@@ -34,8 +34,7 @@ export class FunctionInfo {
           if (type && type.toLowerCase() === 'http') {
             this.httpOutputName = name;
             this.outputBindings[name] = Object.assign(bindings[name], { converter: toRpcHttp });
-          }
-          else {
+          } else {
             this.outputBindings[name] = Object.assign(bindings[name], { converter: toTypedData });
           }
         });

--- a/src/FunctionInfo.ts
+++ b/src/FunctionInfo.ts
@@ -34,7 +34,8 @@ export class FunctionInfo {
           if (type && type.toLowerCase() === 'http') {
             this.httpOutputName = name;
             this.outputBindings[name] = Object.assign(bindings[name], { converter: toRpcHttp });
-          } else {
+          }
+          else {
             this.outputBindings[name] = Object.assign(bindings[name], { converter: toTypedData });
           }
         });

--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -228,8 +228,10 @@ export class WorkerChannel implements IWorkerChannel {
       response.outputData = [];
 
       // As legacy behavior, falsy values get serialized to `null` in AzFunctions.
-      // This breaks Durable Functions expectations so we check if we're serializing
-      // for durable and, if so, ensure falsy values get serialized.
+      // This breaks Durable Functions expectations, where customers expect any
+      // JSON-serializable values to be preserved by the framework,
+      // so we check if we're serializing for durable and, if so, ensure falsy
+      // values get serialized.
       let isDurableBinding = info?.bindings?.name?.type == 'activityTrigger';
 
       try {

--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -226,11 +226,12 @@ export class WorkerChannel implements IWorkerChannel {
       // explicitly set outputData to empty array to concat later
       response.outputData = [];
 
+      let returnBinding = info.getReturnBinding();
+      let isDurableBinding = returnBinding === 'orchestrationTrigger';
       try {
-        if (result) {
-          let returnBinding = info.getReturnBinding();
+        if (result || (isDurableBinding && result != null)) {
           // Set results from return / context.done
-          if (result.return) {
+          if (result.return || (isDurableBinding && result.return != null)) {
             if (this._v1WorkerBehavior) {
               response.returnValue = toTypedData(result.return);
             } else {

--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -229,10 +229,11 @@ export class WorkerChannel implements IWorkerChannel {
       // As legacy behavior, falsy values get serialized to `null` in AzFunctions.
       // This breaks Durable Functions expectations so we check if we're serializing
       // for durable and, if so, ensure falsy values get serialized.
-      let returnBinding = info.getReturnBinding();
-      let isDurableBinding = returnBinding === 'orchestrationTrigger';
+      let isDurableBinding = info?.bindings?.name?.type == 'activityTrigger';
+
       try {
         if (result || (isDurableBinding && result != null)) {
+          let returnBinding = info.getReturnBinding();
           // Set results from return / context.done
           if (result.return || (isDurableBinding && result.return != null)) {
             if (this._v1WorkerBehavior) {

--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -226,6 +226,9 @@ export class WorkerChannel implements IWorkerChannel {
       // explicitly set outputData to empty array to concat later
       response.outputData = [];
 
+      // As legacy behavior, falsy values get serialized to `null` in AzFunctions.
+      // This breaks Durable Functions expectations so we check if we're serializing
+      // for durable and, if so, ensure falsy values get serialized.
       let returnBinding = info.getReturnBinding();
       let isDurableBinding = returnBinding === 'orchestrationTrigger';
       try {

--- a/test/WorkerChannelTests.ts
+++ b/test/WorkerChannelTests.ts
@@ -674,5 +674,44 @@ describe('WorkerChannel', () => {
 
       sendInvokeMessage([httpInputData], getHttpTriggerDataMock());
     });
+
+    it ('returns and serializes falsy value in Durable: ""', () => {
+      loader.getFunc.returns((context) => context.done(null, ""));
+      loader.getInfo.returns(new FunctionInfo(orchestratorBinding));
+    
+      sendInvokeMessage([], getHttpTriggerDataMock());
+    
+      const expectedOutput = [];
+      const expectedReturnValue = { 
+        string: ""
+      };
+      assertInvocationSuccess(expectedOutput, expectedReturnValue);
+    });
+    
+    it ('returns and serializes falsy value in Durable: 0', () => {
+      loader.getFunc.returns((context) => context.done(null, 0));
+      loader.getInfo.returns(new FunctionInfo(orchestratorBinding));
+    
+      sendInvokeMessage([], getHttpTriggerDataMock());
+    
+      const expectedOutput = [];
+      const expectedReturnValue = { 
+        int: 0
+      };
+      assertInvocationSuccess(expectedOutput, expectedReturnValue);
+    });
+    
+    it ('returns and serializes falsy value in Durable: false', () => {
+      loader.getFunc.returns((context) => context.done(null, false));
+      loader.getInfo.returns(new FunctionInfo(orchestratorBinding));
+    
+      sendInvokeMessage([], getHttpTriggerDataMock());
+    
+      const expectedOutput = [];
+      const expectedReturnValue = { 
+        json: "false"
+      };
+      assertInvocationSuccess(expectedOutput, expectedReturnValue)
+    });
   });
 })

--- a/test/WorkerChannelTests.ts
+++ b/test/WorkerChannelTests.ts
@@ -684,46 +684,7 @@ describe('WorkerChannel', () => {
 
       sendInvokeMessage([httpInputData], getHttpTriggerDataMock());
     });
-    
-    it ('returns and serializes falsy value in Durable: ""', () => {
-      loader.getFunc.returns((context) => context.done(null, ""));
-      loader.getInfo.returns(new FunctionInfo(activityBinding));
-    
-      sendInvokeMessage([], getHttpTriggerDataMock());
-    
-      const expectedOutput = [];
-      const expectedReturnValue = { 
-        string: ""
-      };
-      assertInvocationSuccess(expectedOutput, expectedReturnValue);
-    });
-    
-    it ('returns and serializes falsy value in Durable: 0', () => {
-      loader.getFunc.returns((context) => context.done(null, 0));
-      loader.getInfo.returns(new FunctionInfo(activityBinding));
-    
-      sendInvokeMessage([], getHttpTriggerDataMock());
-    
-      const expectedOutput = [];
-      const expectedReturnValue = { 
-        int: 0
-      };
-      assertInvocationSuccess(expectedOutput, expectedReturnValue);
-    });
-    
-    it ('returns and serializes falsy value in Durable: false', () => {
-      loader.getFunc.returns((context) => context.done(null, false));
-      loader.getInfo.returns(new FunctionInfo(activityBinding));
-    
-      sendInvokeMessage([], getHttpTriggerDataMock());
-    
-      const expectedOutput = [];
-      const expectedReturnValue = { 
-        json: "false"
-      };
-      assertInvocationSuccess(expectedOutput, expectedReturnValue)
-    });
-    
+
     it('responds to worker status', async () => {
       stream.addTestMessage({
         requestId: 'id',
@@ -739,5 +700,46 @@ describe('WorkerChannel', () => {
       });
     });
 
+    it ('returns and serializes falsy value in Durable: ""', () => {
+      loader.getFunc.returns((context) => context.done(null, ""));
+      loader.getInfo.returns(new FunctionInfo(activityBinding));
+
+      sendInvokeMessage([], getHttpTriggerDataMock());
+
+      const expectedOutput = [];
+      const expectedReturnValue = { 
+        string: ""
+      };
+      assertInvocationSuccess(expectedOutput, expectedReturnValue);
+    });
+
+    it ('returns and serializes falsy value in Durable: 0', () => {
+      loader.getFunc.returns((context) => context.done(null, 0));
+      loader.getInfo.returns(new FunctionInfo(activityBinding));
+
+      sendInvokeMessage([], getHttpTriggerDataMock());
+
+      const expectedOutput = [];
+      const expectedReturnValue = { 
+        int: 0
+      };
+      assertInvocationSuccess(expectedOutput, expectedReturnValue);
+    });
+
+    it ('returns and serializes falsy value in Durable: false', () => {
+      loader.getFunc.returns((context) => context.done(null, false));
+      loader.getInfo.returns(new FunctionInfo(activityBinding));
+
+      sendInvokeMessage([], getHttpTriggerDataMock());
+
+      const expectedOutput = [];
+      const expectedReturnValue = { 
+        json: "false"
+      };
+      assertInvocationSuccess(expectedOutput, expectedReturnValue)
+    });
+
   });
+
+
 })

--- a/test/WorkerChannelTests.ts
+++ b/test/WorkerChannelTests.ts
@@ -86,6 +86,11 @@ describe('WorkerChannel', () => {
     direction: 1,
     dataType: 1
   };
+  const activityTriggerBinding = {
+    type: "activityTrigger",
+    direction: 1,
+    dataType: 1
+  };
   const httpInputBinding = { 
     type: "httpTrigger",
     direction: 0,
@@ -126,6 +131,11 @@ describe('WorkerChannel', () => {
       test: orchestrationTriggerBinding
     }
   };
+  const activityBinding = {
+    bindings: {
+      name: activityTriggerBinding
+    }
+  }
   const queueTriggerBinding = {
     bindings: {
       test: {
@@ -677,7 +687,7 @@ describe('WorkerChannel', () => {
 
     it ('returns and serializes falsy value in Durable: ""', () => {
       loader.getFunc.returns((context) => context.done(null, ""));
-      loader.getInfo.returns(new FunctionInfo(orchestratorBinding));
+      loader.getInfo.returns(new FunctionInfo(activityBinding));
     
       sendInvokeMessage([], getHttpTriggerDataMock());
     
@@ -690,7 +700,7 @@ describe('WorkerChannel', () => {
     
     it ('returns and serializes falsy value in Durable: 0', () => {
       loader.getFunc.returns((context) => context.done(null, 0));
-      loader.getInfo.returns(new FunctionInfo(orchestratorBinding));
+      loader.getInfo.returns(new FunctionInfo(activityBinding));
     
       sendInvokeMessage([], getHttpTriggerDataMock());
     
@@ -703,7 +713,7 @@ describe('WorkerChannel', () => {
     
     it ('returns and serializes falsy value in Durable: false', () => {
       loader.getFunc.returns((context) => context.done(null, false));
-      loader.getInfo.returns(new FunctionInfo(orchestratorBinding));
+      loader.getInfo.returns(new FunctionInfo(activityBinding));
     
       sendInvokeMessage([], getHttpTriggerDataMock());
     


### PR DESCRIPTION
Replaces: https://github.com/Azure/azure-functions-nodejs-worker/pull/364

Due to legacy behavior, falsy values ("", false, 0) in JS currently do not get serialized. We cannot patch this behavior without breaking some JS customers, but also leaving this behavior unpatched breaks Durable Functions. In this PR, I try to find a middle-ground by ensuring that falsy values get serialized only when returning to the Durable Functions output binding.

