### PR TITLE
Update VS Code config to prevent startup prompts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "azureFunctions.showProjectWarning": false
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,12 +1,19 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
-    "version": "0.1.0",
-    "command": "${cwd}/node_modules/.bin/tsc",
-    "isShellCommand": true,
-    "showOutput": "silent",
-    "problemMatcher": "$tsc",
-    "args": [
-        "--watch"
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "npm: watch",
+            "type": "npm",
+            "script": "watch",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": "$tsc-watch",
+            "isBackground": true,
+            "presentation": {
+                "reveal": "never"
+            }
+        }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "build": "rimraf dist && npm run gen && shx mkdir -p dist/azure-functions-language-worker-protobuf/src && shx cp azure-functions-language-worker-protobuf/src/rpc.* dist/azure-functions-language-worker-protobuf/src/. && tsc",
     "build-nomaps": "npm run build -- --sourceMap false",
     "gen": "node scripts/generateProtos.js",
-    "test": "mocha -r ts-node/register ./test/**/*.ts"
+    "test": "mocha -r ts-node/register ./test/**/*.ts",
+    "watch": "tsc --watch"
   },
   "files": [
     "dist"


### PR DESCRIPTION
I fixed the tasks which are very out of date and suppressed a prompt from the Functions extension which is detecting the project in the `test/end-to-end/testFunctionApp` folder