### PR TITLE
Update information on branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-|Branch|Status|
-|---|---|
-|v2.x|[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-nodejs-worker?branchName=v2.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=10&branchName=v2.x)|
-|master|[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-nodejs-worker?branchName=master)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=10&branchName=master)|
-|dev|[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-nodejs-worker?branchName=dev)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=10&branchName=dev)|
+# Azure Functions Node.js Worker
+
+|Branch|Status|[Runtime Version](https://docs.microsoft.com/azure/azure-functions/functions-versions)|Support level|Node.js Versions|
+|---|---|---|---|---|
+|v3.x|[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-nodejs-worker?branchName=v3.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=10&branchName=v3.x)|4|Preview|14|
+|v2.x (default)|[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-nodejs-worker?branchName=v2.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=10&branchName=v2.x)|3|GA (Recommended)|14, 12, 10|
+|v1.x|[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-nodejs-worker?branchName=v1.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=10&branchName=v1.x)|2|GA (Maintenance mode)|10, 8|
+
+> NOTE: The branch corresponds to the _worker_ version, which is intentionally decoupled from the _runtime_ version.
 
 ## Getting Started
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,13 +10,9 @@ name: $(WORKER_VERSION)-$(Date:yyyyMMdd)$(Rev:.r)
 pr:
   branches:
     include:
-      - master
-      - dev
       - v2.x
 
 trigger:
-- master
-- dev
 - v2.x
 
 jobs:
@@ -119,7 +115,7 @@ jobs:
       failTaskOnFailedTests: true
 
 - job: BuildArtifacts  
-  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['Build.SourceBranch'], 'refs/heads/v2.x'), eq(variables['UPLOADPACKAGETOPRERELEASEFEED'], true)))
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/v2.x'), eq(variables['UPLOADPACKAGETOPRERELEASEFEED'], true))
   pool:
     vmImage: 'vs2017-win2016'
   steps:

--- a/types/public/package.json
+++ b/types/public/package.json
@@ -4,7 +4,7 @@
   "description": "Azure Functions types for Typescript",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Azure/azure-functions-nodejs-worker/tree/master/types/public"
+    "url": "https://github.com/Azure/azure-functions-nodejs-worker/tree/v2.x/types/public"
   },
   "keywords": [
     "azure-functions",
@@ -13,7 +13,9 @@
   "types": "./Main.d.ts",
   "typesVersions": {
     ">=3.1": {
-      "*": ["ts3.1/*"]
+      "*": [
+        "ts3.1/*"
+      ]
     }
   },
   "author": "Microsoft",


### PR DESCRIPTION
And remove references to dev/master because they are not used.

I think the default branch should always have a table like this at the top of the README since it's the home-page of the repo, but I figure non-default branches can just include the info for their version version instead of the whole table (see https://github.com/Azure/azure-functions-nodejs-worker/pull/425 for v1.x example).