### PR TITLE
Fix build errors in generateProto.js script

### DIFF
--- a/scripts/generateProtos.js
+++ b/scripts/generateProtos.js
@@ -1,52 +1,45 @@
 const util = require("util");
-
 const exec = util.promisify(require("child_process").exec);
-const readdirp = util.promisify(require("readdirp"));
-
-const protoRoot = "azure-functions-language-worker-protobuf/src/proto";
-const masterProto = "azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto";
-
-const jsOut = "azure-functions-language-worker-protobuf/src/rpc.js";
-const jsStaticOut = "azure-functions-language-worker-protobuf/src/rpc_static.js";
-const dTsOut = "azure-functions-language-worker-protobuf/src/rpc.d.ts";
+const path = require("path");
 
 async function generateProtos() {
-    const shared = await getFiles(`./${protoRoot}/shared`, "*.proto");
-    const deps = await getFiles(`./${protoRoot}`, "!FunctionRpc*", "!*shared");
+    try {
+        const protoSrc = path.join(__dirname, '..', 'azure-functions-language-worker-protobuf', 'src');
+        const protoRoot = path.join(protoSrc, 'proto');
 
-    const allFiles = `${shared} ${deps} ${masterProto}`;
+        const protoFiles = [
+            path.join(protoRoot, 'shared', 'NullableTypes.proto'),
+            path.join(protoRoot, 'identity', 'ClaimsIdentityRpc.proto'),
+            path.join(protoRoot, 'FunctionRpc.proto')
+        ].join(' ');
 
-    console.log("Compiling protobuf definitions..");
-    genJs(allFiles)
-        .then(data => console.log("Compiled to JavaScript."))
-        .catch(err => console.log(`Could not compile to JavaScript: ${err}`));
-    
-    // Don't generate with Node.js v12 until resolved: https://github.com/protobufjs/protobuf.js/issues/1275
-    if ((process.version.startsWith("v12") || process.version.startsWith("v14")) && process.platform === 'win32') {
-        console.warn("Warning! Could not compile to TypeScript for Node.js 12 or 14 and Windows OS. Do not change public interfaces.");
-    } else {
-        genTs(allFiles)
-        .then(data => console.log("Compiled to TypeScript."))
-        .catch(err => console.log(`Could not compile to TypeScript: ${err}`));
+        console.log("Compiling protobuf definitions...");
+
+        console.log('Compiling to JavaScript...');
+        const jsOut = path.join(protoSrc, 'rpc.js');
+        await run(`pbjs -t json-module -w commonjs -o ${jsOut} ${protoFiles}`);
+        console.log(`Compiled to JavaScript: "${jsOut}"`);
+
+        console.log('Compiling to JavaScript static module...');
+        const jsStaticOut = path.join(protoSrc, 'rpc_static.js');
+        await run(`pbjs -t static-module -o ${jsStaticOut} ${protoFiles}`);
+        console.log(`Compiled to JavaScript static module: "${jsStaticOut}"`);
+
+        console.log('Compiling to TypeScript...');
+        const dTsOut = path.join(protoSrc, 'rpc.d.ts');
+        await run(`pbts -o ${dTsOut} ${jsStaticOut}`);
+        console.log(`Compiled to TypeScript: "${dTsOut}"`);
+    } catch (error) {
+        console.error('Failed to compile protobuf definitions:');
+        console.error(error.message);
+        process.exit(-1);
     }
 };
 
-async function getFiles(root, fileFilter, directoryFilter) {
-    return readdirp({ root, fileFilter, directoryFilter })
-        .then(data => getDelimitedFiles(data));
-}
-
-function getDelimitedFiles(entryInfo) {
-    return entryInfo.files.map(entry => entry.fullPath).reduce((acc, curr) => `${acc} ${curr}`);
-}
-
-function genJs(files) {
-    return exec(`pbjs -t json-module -w commonjs -o ${jsOut} ${files}`);
-}
-
-function genTs(files) {
-    return exec(`pbjs -t static-module -o ${jsStaticOut} ${files}`)
-        .then(exec(`pbts -o ${dTsOut} ${jsStaticOut}`));
+async function run(command) {
+    const { stdout, stderr } = await exec(command);
+    console.log(stdout);
+    console.error(stderr);
 }
 
 generateProtos();


### PR DESCRIPTION
I'm getting this error pretty often when I run a build locally:

> UnhandledPromiseRejectionWarning: Error: Command failed: pbts -o azure-functions-language-worker-protobuf/src/rpc.d.ts azure-functions-language-worker-protobuf/src/rpc_static.js
ERROR: Unable to find the source file or directory /Users/erijiz/Repos/js-worker/azure-functions-language-worker-protobuf/src/rpc_static.js

I think it's a problem where the `exec` stuff isn't properly awaited and causes a race condition, which looks like it has already been fixed on the v3.x branch. I took some logic from that branch and fixed a few other things:
- Don't rely on readdirp - it's overkill and was not properly listed in devDependencies (causing another build error)
- Remove warning about 'issues/1275' - it appears to have been fixed
- Handle errors properly so that it fails the process rather than getting a `UnhandledPromiseRejectionWarning`