### PR TITLE
Remove `| undefined` from Request types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -86,19 +86,19 @@ declare module '@azure/functions' {
      * HTTP request headers.
      */
     export interface HttpRequestHeaders {
-        [name: string]: string | undefined;
+        [name: string]: string;
     }
     /**
      * Query string parameter keys and values from the URL.
      */
     export interface HttpRequestQuery {
-        [name: string]: string | undefined;
+        [name: string]: string;
     }
     /**
      * Route parameter keys and values.
      */
     export interface HttpRequestParams {
-        [name: string]: string | undefined;
+        [name: string]: string;
     }
     /**
      * HTTP request object. Provided to your function when using HTTP Bindings.


### PR DESCRIPTION
This was added in https://github.com/Azure/azure-functions-nodejs-worker/pull/359, but it essentially forces our users to do strict null checking and has a few other downsides as discussed in https://github.com/Azure/azure-functions-nodejs-worker/issues/381. The better solution is to remove `| undefined` and people that want to replicate this behavior can set [noUncheckedIndexedAccess](https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess) to true in their tsconfig.json.


Fixes https://github.com/Azure/azure-functions-nodejs-worker/issues/381