### PR TITLE
Fix type for ContextBindingData.invocationId to be defined

### DIFF
--- a/src/Context.ts
+++ b/src/Context.ts
@@ -1,4 +1,12 @@
-import { BindingDefinition, Context, ExecutionContext, Logger, TraceContext } from '@azure/functions';
+import {
+    BindingDefinition,
+    Context,
+    ContextBindingData,
+    ContextBindings,
+    ExecutionContext,
+    Logger,
+    TraceContext,
+} from '@azure/functions';
 import { v4 as uuid } from 'uuid';
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
 import {
@@ -24,7 +32,7 @@ export function CreateContextAndInputs(
 ) {
     const context = new InvocationContext(info, request, logCallback, callback);
 
-    const bindings: Dict<any> = {};
+    const bindings: ContextBindings = {};
     const inputs: any[] = [];
     let httpInput: RequestProperties | undefined;
     for (const binding of <rpc.IParameterBinding[]>request.inputData) {
@@ -73,8 +81,8 @@ export function CreateContextAndInputs(
 class InvocationContext implements Context {
     invocationId: string;
     executionContext: ExecutionContext;
-    bindings: Dict<any>;
-    bindingData: Dict<any>;
+    bindings: ContextBindings;
+    bindingData: ContextBindingData;
     traceContext: TraceContext;
     bindingDefinitions: BindingDefinition[];
     log: Logger;
@@ -174,7 +182,7 @@ function logWithAsyncCheck(
 
 export interface InvocationResult {
     return: any;
-    bindings: Dict<any>;
+    bindings: ContextBindings;
 }
 
 export type DoneCallback = (err?: Error | string, result?: any) => void;

--- a/src/converters/BindingConverters.ts
+++ b/src/converters/BindingConverters.ts
@@ -1,6 +1,5 @@
-import { BindingDefinition } from '@azure/functions';
+import { BindingDefinition, ContextBindingData } from '@azure/functions';
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
-import { Dict } from '../Context';
 import { FunctionInfo } from '../FunctionInfo';
 import { fromTypedData } from './RpcConverters';
 
@@ -21,9 +20,9 @@ export function getBindingDefinitions(info: FunctionInfo): BindingDefinition[] {
     });
 }
 
-export function getNormalizedBindingData(request: rpc.IInvocationRequest): Dict<any> {
-    const bindingData: Dict<any> = {
-        invocationId: request.invocationId,
+export function getNormalizedBindingData(request: rpc.IInvocationRequest): ContextBindingData {
+    const bindingData: ContextBindingData = {
+        invocationId: <string>request.invocationId,
     };
 
     // node binding data is camel cased due to language convention

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,7 +22,11 @@ declare module '@azure/functions' {
      * Context binding data. Provided to your function trigger metadata and function invocation data.
      */
     export interface ContextBindingData {
-        invocationId?: string | null;
+        /**
+         * A unique GUID per function invocation.
+         */
+        invocationId: string;
+
         [name: string]: any;
     }
     /**


### PR DESCRIPTION
I don't know why, but the worker is copying the exact same `invocationId` to `Context`, `ContextBindingData`, and `ExecutionContext`. Regardless, we should be consistent between all three in the types and it should always be defined.