### PR TITLE
Clean up Timer type comments

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -260,25 +260,31 @@ declare module '@azure/functions' {
          */
         verbose(...args: any[]): void;
     }
+    /**
+     * Timer schedule information. Provided to your function when using a timer binding.
+     */
     export interface Timer {
+        /**
+         * Whether this timer invocation is due to a missed schedule occurrence.
+         */
         isPastDue: boolean;
         schedule: {
             /**
-             * Describes whether the timer for daylight saving based on the timer's time zone
+             * Whether intervals between invocations should account for DST.
              */
             adjustForDST: boolean;
         };
         scheduleStatus: {
             /**
-             * Describes the last recorded schedule occurence. Date ISO string.
+             * The last recorded schedule occurrence. Date ISO string.
              */
             last: string;
             /**
-             * Describes the expected next schedule occurrence
+             * The expected next schedule occurrence. Date ISO string.
              */
             next: string;
             /**
-             * Describes the last time this record was updated. This is used to re-calculate `next` with the current schedule after a host restart. Date ISO string.
+             * The last time this record was updated. This is used to re-calculate `next` with the current schedule after a host restart. Date ISO string.
              */
             lastUpdated: string;
         };


### PR DESCRIPTION
Comments for properties of the object copied over from webjobs sdk (for example [here](https://github.com/Azure/azure-webjobs-sdk-extensions/blob/9c87af74f90159f8b987c77aa77546f55a62a84e/src/WebJobs.Extensions/Extensions/Timers/TimerInfo.cs#L45)). Comment for `Timer` based off of similar comment for `HttpRequest`
