### PR TITLE
Fix Cosmos e2e test

### DIFF
--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/Helpers/CosmosDBHelpers.cs
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/Helpers/CosmosDBHelpers.cs
@@ -57,7 +57,7 @@ namespace Azure.Functions.NodeJs.Tests.E2E
                     retrievedDocument = await _docDbClient.ReadDocumentAsync(docUri, new RequestOptions { PartitionKey = new PartitionKey(docId) });
                     return true;
                 }
-                catch (DocumentClientException ex) when (ex.Error.Code == "NotFound")
+                catch (DocumentClientException ex) when (ex.Error.Code == "NotFound" || ex.Error.Code == "Not Found")
                 {
                     return false;
                 }


### PR DESCRIPTION
A Cosmos DB error code changed over the weekend and our e2e test fails because it's not retrying `ReadDocument` when it should be.

cc @Francisco-Gamino 