### PR TITLE
Clean up licensing

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,8 @@
 {
     "parser": "@typescript-eslint/parser",
     "plugins": [
-        "@typescript-eslint"
+        "@typescript-eslint",
+        "header"
     ],
     "parserOptions": {
         "project": "tsconfig.json",
@@ -14,6 +15,15 @@
         "plugin:prettier/recommended"
     ],
     "rules": {
+        "header/header": [
+            2,
+            "line",
+            [
+                " Copyright (c) .NET Foundation. All rights reserved.",
+                " Licensed under the MIT License."
+            ],
+            2
+        ],
         "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/ban-types": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
                 "chai-as-promised": "^7.1.1",
                 "eslint": "^7.32.0",
                 "eslint-config-prettier": "^8.3.0",
+                "eslint-plugin-header": "^3.1.1",
                 "eslint-plugin-prettier": "^4.0.0",
                 "husky": "^7.0.2",
                 "mocha": "^5.2.0",
@@ -2123,6 +2124,15 @@
             },
             "peerDependencies": {
                 "eslint": ">=7.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-header": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
+            "integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==",
+            "dev": true,
+            "peerDependencies": {
+                "eslint": ">=7.7.0"
             }
         },
         "node_modules/eslint-plugin-prettier": {
@@ -9172,6 +9182,13 @@
             "version": "8.3.0",
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
             "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+            "dev": true,
+            "requires": {}
+        },
+        "eslint-plugin-header": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
+            "integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==",
             "dev": true,
             "requires": {}
         },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "chai": "^4.2.0",
         "chai-as-promised": "^7.1.1",
         "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-header": "^3.1.1",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint": "^7.32.0",
         "husky": "^7.0.2",

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 import {
     BindingDefinition,
     Context,

--- a/src/FunctionInfo.ts
+++ b/src/FunctionInfo.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
 import { toRpcHttp, toTypedData } from './converters';
 

--- a/src/FunctionLoader.ts
+++ b/src/FunctionLoader.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 import * as url from 'url';
 import { isFunction, isObject } from 'util';
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';

--- a/src/GrpcService.ts
+++ b/src/GrpcService.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 import * as grpc from 'grpc';
 import * as protobuf from 'protobufjs';
 // import protobufjs json descriptor

--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 import * as parseArgs from 'minimist';
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
 import { FunctionLoader } from './FunctionLoader';

--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 import { Context } from '@azure/functions';
 import { format, isFunction } from 'util';
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';

--- a/src/augmenters/InvocationRequestAugmenters.ts
+++ b/src/augmenters/InvocationRequestAugmenters.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
 
 /**

--- a/src/augmenters/index.ts
+++ b/src/augmenters/index.ts
@@ -1,1 +1,4 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 export * from './InvocationRequestAugmenters';

--- a/src/converters/BindingConverters.ts
+++ b/src/converters/BindingConverters.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 import { BindingDefinition, ContextBindingData } from '@azure/functions';
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
 import { FunctionInfo } from '../FunctionInfo';

--- a/src/converters/RpcConverters.ts
+++ b/src/converters/RpcConverters.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 import { TraceContext } from '@azure/functions';
 import { isLong } from 'long';
 import {

--- a/src/converters/RpcHttpConverters.ts
+++ b/src/converters/RpcHttpConverters.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 import { Cookie, HttpMethod } from '@azure/functions';
 import {
     AzureFunctionsRpcMessages as rpc,

--- a/src/converters/index.ts
+++ b/src/converters/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 export * from './BindingConverters';
 export * from './RpcConverters';
 export * from './RpcHttpConverters';

--- a/src/http/Request.ts
+++ b/src/http/Request.ts
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License.
+
 import { HttpMethod, HttpRequest } from '@azure/functions';
 
 export class RequestProperties implements HttpRequest {

--- a/src/http/Response.ts
+++ b/src/http/Response.ts
@@ -1,7 +1,8 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 import { Cookie } from '@azure/functions';
 
-// Copyright (c) .NET Foundation. All rights thiserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
 interface IResponse {
     statusCode?: string | number;
     headers: {

--- a/src/nodejsWorker.ts
+++ b/src/nodejsWorker.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 const logPrefix = 'LanguageWorkerConsoleLog';
 const errorPrefix = logPrefix + '[error] ';
 const warnPrefix = logPrefix + '[warn] ';

--- a/src/utils/InternalException.ts
+++ b/src/utils/InternalException.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 export class InternalException extends Error {
     public isAzureFunctionsInternalException = true;
 }

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -1,6 +1,9 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 /**
- *  Use these methods only if you want to guarantee the messages reach the host despite potential performance impact. 
-    Otherwise, please stick to utilizing the gRPC channel to propagate these messages with category: RpcLogCategory.System
+ * Use these methods only if you want to guarantee the messages reach the host despite potential performance impact.
+ * Otherwise, please stick to utilizing the gRPC channel to propagate these messages with category: RpcLogCategory.System
  **/
 
 const logPrefix = 'LanguageWorkerConsoleLog';

--- a/test/BindingConvertersTests.ts
+++ b/test/BindingConvertersTests.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 import { expect } from 'chai';
 import { fromString } from 'long';
 import 'mocha';

--- a/test/ContextTests.ts
+++ b/test/ContextTests.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 import { Context } from '@azure/functions';
 import { expect } from 'chai';
 import 'mocha';

--- a/test/FunctionInfoTests.ts
+++ b/test/FunctionInfoTests.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 import { expect } from 'chai';
 import 'mocha';
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';

--- a/test/FunctionLoaderTests.ts
+++ b/test/FunctionLoaderTests.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 import 'mocha';
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
 import { FunctionLoader } from '../src/FunctionLoader';

--- a/test/RpcConvertersTests.ts
+++ b/test/RpcConvertersTests.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 import { expect } from 'chai';
 import 'mocha';
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';

--- a/test/RpcHttpConverters.ts
+++ b/test/RpcHttpConverters.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 import { Cookie } from '@azure/functions';
 import { expect } from 'chai';
 import 'mocha';

--- a/test/TestEventStream.ts
+++ b/test/TestEventStream.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 import { EventEmitter } from 'events';
 import * as sinon from 'sinon';
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';

--- a/test/TypesTests.ts
+++ b/test/TypesTests.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 import { expect } from 'chai';
 import * as cp from 'child_process';
 import 'mocha';

--- a/test/WorkerChannelTests.ts
+++ b/test/WorkerChannelTests.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 import { expect } from 'chai';
 import 'mocha';
 import * as sinon from 'sinon';

--- a/test/WorkerTests.ts
+++ b/test/WorkerTests.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 import { expect } from 'chai';
 import 'mocha';
 import { startNodeWorker } from '../src/Worker';

--- a/types/LICENSE
+++ b/types/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) .NET Foundation. All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 declare module '@azure/functions' {
     /**
      * Interface for your Azure Function code. This function must be exported (via module.exports or exports)

--- a/types/index.test.ts
+++ b/types/index.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
 // This file will be compiled by multiple versions of TypeScript as decribed in ./test/TypesTests.ts to verify there are no errors
 
 import { AzureFunction, Context, Cookie, HttpMethod, HttpRequest } from '@azure/functions';


### PR DESCRIPTION
1. Copy the existing license at the root of the repo to the `types` folder so that it's included when we ship the npm package
2. Add an eslint rule to auto-add the copyright header to all files