### PR TITLE
Bump types package to 3.0.0

### DIFF
--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/functions",
-    "version": "3.0.0-beta.0",
+    "version": "3.0.0",
     "description": "Azure Functions types for Typescript",
     "repository": {
         "type": "git",


### PR DESCRIPTION
I don't see the need to do a beta release because it's so similar to v2.

Here's the general issue on versioning: https://github.com/Azure/azure-functions-nodejs-worker/issues/428