### PR TITLE
Combine Request and RequestProperties

### DIFF
--- a/src/converters/RpcHttpConverters.ts
+++ b/src/converters/RpcHttpConverters.ts
@@ -1,13 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Cookie, HttpMethod } from '@azure/functions';
+import { Cookie } from '@azure/functions';
 import {
     AzureFunctionsRpcMessages as rpc,
     INullableString,
 } from '../../azure-functions-language-worker-protobuf/src/rpc';
 import { Dict } from '../Context';
-import { RequestProperties } from '../http/Request';
 import {
     fromTypedData,
     toNullableBool,
@@ -19,31 +18,12 @@ import {
 } from './RpcConverters';
 
 /**
- * Converts 'IRpcHttp' input from the RPC layer to a JavaScript object.
- * @param rpcHttp RPC layer representation of an HTTP request
- */
-export function fromRpcHttp(rpcHttp: rpc.IRpcHttp): RequestProperties {
-    const httpContext: RequestProperties = {
-        method: <HttpMethod>rpcHttp.method,
-        url: <string>rpcHttp.url,
-        originalUrl: <string>rpcHttp.url,
-        headers: fromNullableMapping(rpcHttp.nullableHeaders, rpcHttp.headers),
-        query: fromNullableMapping(rpcHttp.nullableQuery, rpcHttp.query),
-        params: fromNullableMapping(rpcHttp.nullableParams, rpcHttp.params),
-        body: fromTypedData(<rpc.ITypedData>rpcHttp.body),
-        rawBody: fromRpcHttpBody(<rpc.ITypedData>rpcHttp.body),
-    };
-
-    return httpContext;
-}
-
-/**
  * Converts the provided body from the RPC layer to the appropriate javascript object.
  * Body of type 'byte' is a special case and it's converted to it's utf-8 string representation.
  * This is to avoid breaking changes in v2.
  * @param body The body from the RPC layer.
  */
-function fromRpcHttpBody(body: rpc.ITypedData) {
+export function fromRpcHttpBody(body: rpc.ITypedData) {
     if (body && body.bytes) {
         return (<Buffer>body.bytes).toString();
     } else {
@@ -51,7 +31,7 @@ function fromRpcHttpBody(body: rpc.ITypedData) {
     }
 }
 
-function fromNullableMapping(
+export function fromNullableMapping(
     nullableMapping: { [k: string]: INullableString } | null | undefined,
     originalMapping?: { [k: string]: string } | null
 ): Dict<string> {

--- a/src/http/Request.ts
+++ b/src/http/Request.ts
@@ -1,27 +1,33 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-import { HttpMethod, HttpRequest } from '@azure/functions';
+import { HttpMethod, HttpRequest, HttpRequestHeaders, HttpRequestParams, HttpRequestQuery } from '@azure/functions';
+import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
+import { fromTypedData } from '../converters/RpcConverters';
+import { fromNullableMapping, fromRpcHttpBody } from '../converters/RpcHttpConverters';
 
-export class RequestProperties implements HttpRequest {
-    method: HttpMethod | null = null;
-    url = '';
-    originalUrl = '';
-    headers: { [key: string]: string } = {};
-    query: { [key: string]: string } = {};
-    params: { [key: string]: string } = {};
-    body?: any;
-    rawBody?: any;
-    [key: string]: any;
-}
+export class Request implements HttpRequest {
+    public method: HttpMethod | null;
+    public url: string;
+    public originalUrl: string;
+    public headers: HttpRequestHeaders;
+    public query: HttpRequestQuery;
+    public params: HttpRequestParams;
+    public body?: any;
+    public rawBody?: any;
 
-export class Request extends RequestProperties {
-    constructor(httpInput: RequestProperties) {
-        super();
-        Object.assign(this, httpInput);
+    public constructor(rpcHttp: rpc.IRpcHttp) {
+        this.method = <HttpMethod>rpcHttp.method;
+        this.url = <string>rpcHttp.url;
+        this.originalUrl = <string>rpcHttp.url;
+        this.headers = fromNullableMapping(rpcHttp.nullableHeaders, rpcHttp.headers);
+        this.query = fromNullableMapping(rpcHttp.nullableQuery, rpcHttp.query);
+        this.params = fromNullableMapping(rpcHttp.nullableParams, rpcHttp.params);
+        this.body = fromTypedData(<rpc.ITypedData>rpcHttp.body);
+        this.rawBody = fromRpcHttpBody(<rpc.ITypedData>rpcHttp.body);
     }
 
-    get(field: string): string | undefined {
+    public get(field: string): string | undefined {
         return this.headers && this.headers[field.toLowerCase()];
     }
 }


### PR DESCRIPTION
See this code for an http trigger:
```typescript
const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
    context.log('HTTP trigger function processed a request.');

    console.log(context.req === req);
```

Currently, `false` gets printed. That makes it difficult for us to add things to Request (like the form and client-principal work) because we'd have to add it in both places. My fix combines the two and ensures people will get the same experience no matter which `req` they use.