### PR TITLE
Include package.json in nuget package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-functions-nodejs-worker",
-    "version": "4.0.0",
+    "version": "3.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-functions-nodejs-worker",
-            "version": "4.0.0",
+            "version": "3.0.0",
             "license": "(MIT OR Apache-2.0)",
             "dependencies": {
                 "@grpc/grpc-js": "^1.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-functions-nodejs-worker",
     "author": "Microsoft Corporation",
-    "version": "4.0.0",
+    "version": "3.0.0",
     "description": "Microsoft Azure Functions NodeJS Worker",
     "license": "(MIT OR Apache-2.0)",
     "dependencies": {

--- a/package.ps1
+++ b/package.ps1
@@ -17,6 +17,7 @@ remove-item pkg -Recurse -ErrorAction Ignore
 New-Item ./pkg/dist/src -Type Directory
 copy-item ./dist/src/nodejsWorker.js ./pkg/dist/src/
 copy-item ./worker.config.json pkg
+copy-item ./package.json pkg
 copy-item ./LICENSE pkg
 copy-item ./NOTICE.html pkg
 ./node_modules/.bin/webpack


### PR DESCRIPTION
While not strictly necessary, it's pretty standard practice to include this in any node.js app as it contains a lot of basic info about the app. For example, the reason you see so many file access checks in https://github.com/Azure/azure-functions-nodejs-worker/issues/449 is because node is looking for the package.json. Unfortunately, this fix supposedly doesn't get rid of the storage file checks which are the main problem in that issue, but still.

Also I noticed the version was at 4 even though we're still on 3 so I fixed that.