### PR TITLE
Add SBOM generation task

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -132,6 +132,11 @@ jobs:
     inputs:
       command: pack
       packagesToPack: '$(System.DefaultWorkingDirectory)\pkg'
+  - task: ManifestGeneratorTask@0
+    displayName: 'SBOM Generation Task'
+    inputs:
+      BuildDropPath: '$(Build.ArtifactStagingDirectory)'
+      Verbosity: 'Information'
   - task: PublishBuildArtifacts@1
     inputs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)'


### PR DESCRIPTION
Modeled after Java worker: https://github.com/Azure/azure-functions-java-worker/pull/494

I ran a test build and the "_manifest" is being included in the drop and everything looks accurate to me.