### PR TITLE
Add release pipeline yaml for types package

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -27,5 +27,5 @@ jobs:
       command: custom
       workingDir: '$(Pipeline.Workspace)/nodeWorkerCI/types'
       verbose: true
-      customCommand: 'publish package.tgz --dry-run'
+      customCommand: 'publish package.tgz'
       publishEndpoint: 'TypeScript Types Publish'

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -1,0 +1,31 @@
+trigger: none
+pr: none
+
+resources:
+  pipelines:
+  - pipeline: nodeWorkerCI
+    project: 'Azure Functions'
+    source: Azure.azure-functions-nodejs-worker
+    branch: v3.x
+
+jobs:
+- job: ReleaseTypes 
+  pool:
+    vmImage: 'ubuntu-latest'
+  steps:
+  - task: NodeTool@0
+    displayName: 'Install Node.js'
+    inputs:
+      versionSpec: 14.x
+  - download: nodeWorkerCI
+  - script: mv *.tgz package.tgz
+    displayName: 'Rename tgz file' # because the publish command below requires an exact path
+    workingDirectory: '$(Pipeline.Workspace)/nodeWorkerCI/types'
+  - task: Npm@1
+    displayName: 'npm publish'
+    inputs:
+      command: custom
+      workingDir: '$(Pipeline.Workspace)/nodeWorkerCI/types'
+      verbose: true
+      customCommand: 'publish package.tgz --dry-run'
+      publishEndpoint: 'TypeScript Types Publish'


### PR DESCRIPTION
Related to SBOM work (https://github.com/Azure/azure-functions-nodejs-worker/pull/490), we need to actually use the types package artifact from that build for releasing. Previously it was a non-yaml based release pipeline and it basically created its own artifact.

Example pipeline run: https://azfunc.visualstudio.com/Azure%20Functions/_build/results?buildId=44253&view=results

(I've only tried the publish with `--dry-run` so far)