### PR TITLE
Add build number to worker version when doing nuget pack

### DIFF
--- a/Worker.nuspec
+++ b/Worker.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Microsoft.Azure.Functions.NodeJsWorker</id>
-    <version>3.0.0$version$</version>
+    <version>3.0.0$prereleaseSuffix$</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -1,3 +1,8 @@
+parameters:
+- name: IsPrerelease
+  type: boolean
+  default: true
+
 pr:
   branches:
     include:
@@ -26,6 +31,8 @@ jobs:
       command: pack
       packagesToPack: '$(System.DefaultWorkingDirectory)/pkg'
       packDestination: '$(Build.ArtifactStagingDirectory)/worker'
+      ${{ if eq(parameters.IsPrerelease, true) }}:
+        buildProperties: 'prereleaseSuffix=-alpha.$(Build.BuildNumber)'
   - script: npm prune --production
     displayName: 'npm prune --production' # so that only production dependencies are included in SBOM
   - task: ManifestGeneratorTask@0


### PR DESCRIPTION
The node.js worker nuget package is not getting updated in the prerelease feed because the version doesn't change, meaning it hasn't been doing integration tests on the latest bits. Other language workers automatically change their version, but each worker seems to have a different way of doing it, none of which I particularly like 😝 Instead, my preference is to closely follow https://semver.org/ and here's what that looks like:
- For routine builds, a prerelease tag is added to the end of the version, like "3.0.0-alpha.20211214.16". I specifically like having the date in there so you can quickly see how old a package is
- For planned releases, we will manually update either the minor or patch version in the nuspec file depending on if it's a bug fix or feature release. Then when queueing the build, we will uncheck "IsPrerelease" so that it does not add a prerelease suffix