### PR TITLE
Update build source for release-types pipeline

### DIFF
--- a/azure-pipelines/release-types.yml
+++ b/azure-pipelines/release-types.yml
@@ -5,7 +5,7 @@ resources:
   pipelines:
   - pipeline: nodeWorkerCI
     project: 'Azure Functions'
-    source: Azure.azure-functions-nodejs-worker
+    source: azure-functions-nodejs-worker.build
     branch: v3.x
 
 jobs:


### PR DESCRIPTION
Related to https://github.com/Azure/azure-functions-nodejs-worker/pull/494, I moved/renamed the pipelines so I need to update this reference