### PR TITLE
Bump version

### DIFF
--- a/Worker.nuspec
+++ b/Worker.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Microsoft.Azure.Functions.NodeJsWorker</id>
-    <version>3.0.0$prereleaseSuffix$</version>
+    <version>3.0.1$prereleaseSuffix$</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-functions-nodejs-worker",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-functions-nodejs-worker",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "license": "(MIT OR Apache-2.0)",
             "dependencies": {
                 "@grpc/grpc-js": "^1.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-functions-nodejs-worker",
     "author": "Microsoft Corporation",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "description": "Microsoft Azure Functions NodeJS Worker",
     "license": "(MIT OR Apache-2.0)",
     "dependencies": {


### PR DESCRIPTION
Related to https://github.com/Azure/azure-functions-nodejs-worker/pull/495

Going forward we need to bump the version immediately after every "real" release in order for integration tests to consider our prerelease builds to be the latest (assuming it uses the `-prerelease` flag to list versions which [it does](https://github.com/Azure/azure-functions-core-tools/blob/v4.x/build/BuildSteps.cs#L644)). This makes logical sense - builds going forward are the prerelease to 3.0.1, not 3.0.0 which is already out.