### PR TITLE
Allow Node.js v17.x and v15.x to be used during local development with warning messages

### DIFF
--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -119,11 +119,14 @@ export class WorkerChannel implements IWorkerChannel {
     public workerInitRequest(requestId: string, msg: rpc.WorkerInitRequest) {
         // Validate version
         const version = process.version;
-        if (version.startsWith('v17.') && process.env.AZURE_FUNCTIONS_ENVIRONMENT == 'Development') {
+        if (
+            (version.startsWith('v17.') || version.startsWith('v15.')) &&
+            process.env.AZURE_FUNCTIONS_ENVIRONMENT == 'Development'
+        ) {
             const msg =
                 'Node.js version used (' +
                 version +
-                ') is not officially supported. You may use it during local development, but your function will be deployed to a different Node.js version on Azure.' +
+                ') is not officially supported. You may use it during local development, but must use an officially supported version on Azure.' +
                 ' The version of the Azure Functions runtime you are using (v4) officially supports Node.js v14.x or Node.js v16.x.' +
                 ' Refer to our documentation to see the Node.js versions supported by each version of Azure Functions: https://aka.ms/functions-node-versions';
             systemWarn(msg);

--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -126,8 +126,7 @@ export class WorkerChannel implements IWorkerChannel {
             const msg =
                 'Node.js version used (' +
                 version +
-                ') is not officially supported. You may use it during local development, but must use an officially supported version on Azure.' +
-                ' The version of the Azure Functions runtime you are using (v4) officially supports Node.js v14.x or Node.js v16.x:' +
+                ') is not officially supported. You may use it during local development, but must use an officially supported version on Azure:' +
                 ' https://aka.ms/functions-node-versions';
             this.log({
                 message: msg,

--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -11,7 +11,7 @@ import { toTypedData } from './converters';
 import { IFunctionLoader } from './FunctionLoader';
 import { IEventStream } from './GrpcService';
 import { InternalException } from './utils/InternalException';
-import { systemError, systemWarn } from './utils/Logger';
+import { systemError } from './utils/Logger';
 import LogCategory = rpc.RpcLog.RpcLogCategory;
 import LogLevel = rpc.RpcLog.Level;
 
@@ -127,9 +127,13 @@ export class WorkerChannel implements IWorkerChannel {
                 'Node.js version used (' +
                 version +
                 ') is not officially supported. You may use it during local development, but must use an officially supported version on Azure.' +
-                ' The version of the Azure Functions runtime you are using (v4) officially supports Node.js v14.x or Node.js v16.x.' +
-                ' Refer to our documentation to see the Node.js versions supported by each version of Azure Functions: https://aka.ms/functions-node-versions';
-            systemWarn(msg);
+                ' The version of the Azure Functions runtime you are using (v4) officially supports Node.js v14.x or Node.js v16.x:' +
+                ' https://aka.ms/functions-node-versions';
+            this.log({
+                message: msg,
+                level: LogLevel.Warning,
+                logCategory: LogCategory.System,
+            });
         } else if (!(version.startsWith('v14.') || version.startsWith('v16.'))) {
             const msg =
                 'Incompatible Node.js version' +

--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -11,7 +11,7 @@ import { toTypedData } from './converters';
 import { IFunctionLoader } from './FunctionLoader';
 import { IEventStream } from './GrpcService';
 import { InternalException } from './utils/InternalException';
-import { systemError } from './utils/Logger';
+import { systemError, systemWarn } from './utils/Logger';
 import LogCategory = rpc.RpcLog.RpcLogCategory;
 import LogLevel = rpc.RpcLog.Level;
 
@@ -119,7 +119,15 @@ export class WorkerChannel implements IWorkerChannel {
     public workerInitRequest(requestId: string, msg: rpc.WorkerInitRequest) {
         // Validate version
         const version = process.version;
-        if (!(version.startsWith('v14.') || version.startsWith('v16.'))) {
+        if (version.startsWith('v17.') && process.env.AZURE_FUNCTIONS_ENVIRONMENT == 'Development') {
+            const msg =
+                'Node.js version used (' +
+                version +
+                ') is not officially supported. You may use it during local development, but your function will be deployed to a different Node.js version on Azure.' +
+                ' The version of the Azure Functions runtime you are using (v4) officially supports Node.js v14.x or Node.js v16.x.' +
+                ' Refer to our documentation to see the Node.js versions supported by each version of Azure Functions: https://aka.ms/functions-node-versions';
+            systemWarn(msg);
+        } else if (!(version.startsWith('v14.') || version.startsWith('v16.'))) {
             const msg =
                 'Incompatible Node.js version' +
                 ' (' +

--- a/src/nodejsWorker.ts
+++ b/src/nodejsWorker.ts
@@ -3,7 +3,6 @@
 
 const logPrefix = 'LanguageWorkerConsoleLog';
 const errorPrefix = logPrefix + '[error] ';
-const warnPrefix = logPrefix + '[warn] ';
 const supportedVersions: string[] = ['v14', 'v16'];
 const devOnlyVersions: string[] = ['v15', 'v17'];
 let worker;
@@ -21,12 +20,7 @@ function validateNodeVersion(version) {
             message = "Could not parse Node.js version: '" + version + "'";
             // Unsupported version note: Documentation about Node's stable versions here: https://github.com/nodejs/Release#release-plan and an explanation here: https://medium.com/swlh/understanding-how-node-releases-work-in-2018-6fd356816db4
         } else if (process.env.AZURE_FUNCTIONS_ENVIRONMENT == 'Development' && devOnlyVersions.indexOf(major) >= 0) {
-            const warning =
-                'Node.js version used (' +
-                version +
-                ') is not officially supported. You may use it during local development, but must use an officially supported version on Azure:' +
-                ' https://aka.ms/functions-node-versions';
-            console.warn(warnPrefix + warning);
+            // Allow to continue. Warning message displayed in workerInitRequest (WorkerChannel.ts)
         } else if (supportedVersions.indexOf(major) < 0) {
             message =
                 'Incompatible Node.js version' +

--- a/src/nodejsWorker.ts
+++ b/src/nodejsWorker.ts
@@ -5,6 +5,7 @@ const logPrefix = 'LanguageWorkerConsoleLog';
 const errorPrefix = logPrefix + '[error] ';
 const warnPrefix = logPrefix + '[warn] ';
 const supportedVersions: string[] = ['v14', 'v16'];
+const devOnlyVersions: string[] = ['v15', 'v17'];
 let worker;
 
 // Try validating node version
@@ -19,12 +20,12 @@ function validateNodeVersion(version) {
         if (versionSplit.length != 3) {
             message = "Could not parse Node.js version: '" + version + "'";
             // Unsupported version note: Documentation about Node's stable versions here: https://github.com/nodejs/Release#release-plan and an explanation here: https://medium.com/swlh/understanding-how-node-releases-work-in-2018-6fd356816db4
-        } else if (process.env.AZURE_FUNCTIONS_ENVIRONMENT == 'Development' && major == 'v17') {
+        } else if (process.env.AZURE_FUNCTIONS_ENVIRONMENT == 'Development' && devOnlyVersions.indexOf(major) >= 0) {
             const warning =
                 'Node.js version used (' +
                 version +
-                ') is not officially supported. You may use it during local development, but your function will be deployed to a different Node.js version on Azure.' +
-                ' Refer to our documentation to see the Node.js versions supported by each version of Azure Functions: https://aka.ms/functions-node-versions';
+                ') is not officially supported. You may use it during local development, but must use an officially supported version on Azure:' +
+                ' https://aka.ms/functions-node-versions';
             console.warn(warnPrefix + warning);
         } else if (supportedVersions.indexOf(major) < 0) {
             message =

--- a/src/nodejsWorker.ts
+++ b/src/nodejsWorker.ts
@@ -19,6 +19,13 @@ function validateNodeVersion(version) {
         if (versionSplit.length != 3) {
             message = "Could not parse Node.js version: '" + version + "'";
             // Unsupported version note: Documentation about Node's stable versions here: https://github.com/nodejs/Release#release-plan and an explanation here: https://medium.com/swlh/understanding-how-node-releases-work-in-2018-6fd356816db4
+        } else if (process.env.AZURE_FUNCTIONS_ENVIRONMENT == 'Development' && major == 'v17') {
+            const warning =
+                'Node.js version used (' +
+                version +
+                ') is not officially supported. You may use it during local development, but your function will be deployed to a different Node.js version on Azure.' +
+                ' Refer to our documentation to see the Node.js versions supported by each version of Azure Functions: https://aka.ms/functions-node-versions';
+            console.warn(warnPrefix + warning);
         } else if (supportedVersions.indexOf(major) < 0) {
             message =
                 'Incompatible Node.js version' +


### PR DESCRIPTION
Fixes #363 . Allows Node.js `v17.x` and `v15.x` to be used if function is being run locally (if env variable `AZURE_FUNCTIONS_ENVIRONMENT == "Development"`). Displays a warning to the customer that this version is not officially supported and that the function will be run using a different Node.js version when deployed to Azure.