### PR TITLE
Fix 1ES image demands for types release pipeline

### DIFF
--- a/azure-pipelines/release-types.yml
+++ b/azure-pipelines/release-types.yml
@@ -12,7 +12,8 @@ jobs:
 - job: ReleaseTypes
   pool:
     name: '1ES-Hosted-AzFunc'
-    vmImage: 'MMSUbuntu20.04TLS'
+    demands:
+    - ImageOverride -equals MMSUbuntu20.04TLS
   steps:
   - task: NodeTool@0
     displayName: 'Install Node.js'


### PR DESCRIPTION
Same deal as https://github.com/Azure/azure-functions-nodejs-worker/pull/509, just for a different pipeline