### PR TITLE
Move 'NPM_PUBLISH_ARGS' to a parameter

### DIFF
--- a/azure-pipelines/release-types.yml
+++ b/azure-pipelines/release-types.yml
@@ -1,6 +1,11 @@
 trigger: none
 pr: none
 
+parameters:
+- name: NPM_PUBLISH_ARGS
+  type: string
+  default: '--dry-run'
+
 resources:
   pipelines:
   - pipeline: nodeWorkerCI

--- a/azure-pipelines/release-types.yml
+++ b/azure-pipelines/release-types.yml
@@ -1,10 +1,11 @@
-trigger: none
-pr: none
-
 parameters:
-- name: NPM_PUBLISH_ARGS
+- name: NpmPublishArgs
+  displayName: 'NPM Publish Args'
   type: string
   default: '--dry-run'
+
+trigger: none
+pr: none
 
 resources:
   pipelines:
@@ -33,5 +34,5 @@ jobs:
       command: custom
       workingDir: '$(Pipeline.Workspace)/nodeWorkerCI/drop/types'
       verbose: true
-      customCommand: 'publish package.tgz $(NPM_PUBLISH_ARGS)'
+      customCommand: 'publish package.tgz ${{ parameters.NpmPublishArgs }}'
       publishEndpoint: 'TypeScript Types Publish'


### PR DESCRIPTION
Currently it's a variable, but parameters are better because you can easily set them at queue time (see screenshot) and you can specify the default in the yaml file itself
![Screen Shot 2022-01-19 at 9 55 51 AM](https://user-images.githubusercontent.com/11282622/150187146-a394d498-3617-4514-88d9-4865ad771175.png)

