### PR TITLE
Bump version to 3.1.0

### DIFF
--- a/Worker.nuspec
+++ b/Worker.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Microsoft.Azure.Functions.NodeJsWorker</id>
-    <version>3.0.1$prereleaseSuffix$</version>
+    <version>3.1.0$prereleaseSuffix$</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-functions-nodejs-worker",
-    "version": "3.0.1",
+    "version": "3.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-functions-nodejs-worker",
-            "version": "3.0.1",
+            "version": "3.1.0",
             "license": "(MIT OR Apache-2.0)",
             "dependencies": {
                 "@grpc/grpc-js": "^1.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-functions-nodejs-worker",
     "author": "Microsoft Corporation",
-    "version": "3.0.1",
+    "version": "3.1.0",
     "description": "Microsoft Azure Functions NodeJS Worker",
     "license": "(MIT OR Apache-2.0)",
     "dependencies": {

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/functions",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "description": "Azure Functions types for Typescript",
     "repository": {
         "type": "git",


### PR DESCRIPTION
We want to integrate with the host and this should be considered a feature/minor-version release, mainly due to https://github.com/Azure/azure-functions-nodejs-worker/pull/483.

We need to update the types package version at the same time because they should always be in sync for the major and minor version. The only part they can differ on is the patch version. I'm basing this off of [these docs](https://github.com/DefinitelyTyped/DefinitelyTyped#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library).
