### PR TITLE
Bump version

### DIFF
--- a/Worker.nuspec
+++ b/Worker.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Microsoft.Azure.Functions.NodeJsWorker</id>
-    <version>3.1.0$prereleaseSuffix$</version>
+    <version>3.2.0$prereleaseSuffix$</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-functions-nodejs-worker",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-functions-nodejs-worker",
-            "version": "3.1.0",
+            "version": "3.2.0",
             "license": "(MIT OR Apache-2.0)",
             "dependencies": {
                 "@grpc/grpc-js": "^1.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-functions-nodejs-worker",
     "author": "Microsoft Corporation",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "description": "Microsoft Azure Functions NodeJS Worker",
     "license": "(MIT OR Apache-2.0)",
     "dependencies": {

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/functions",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "description": "Azure Functions types for Typescript",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Normally I'd bump it to 3.1.1 right after we do a release, but I already know the next release will be a "feature" release (3.2.0) because of the [form PR](https://github.com/Azure/azure-functions-nodejs-worker/pull/486) I just merged.