### PR TITLE
Revert "Serialize falsy values for Durable Functions (#383)" in v2.x

### DIFF
--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -246,18 +246,11 @@ export class WorkerChannel implements IWorkerChannel {
             // explicitly set outputData to empty array to concat later
             response.outputData = [];
 
-            // As legacy behavior, falsy values get serialized to `null` in AzFunctions.
-            // This breaks Durable Functions expectations, where customers expect any
-            // JSON-serializable values to be preserved by the framework,
-            // so we check if we're serializing for durable and, if so, ensure falsy
-            // values get serialized.
-            const isDurableBinding = info?.bindings?.name?.type == 'activityTrigger';
-
             try {
-                if (result || (isDurableBinding && result != null)) {
+                if (result) {
                     const returnBinding = info.getReturnBinding();
                     // Set results from return / context.done
-                    if (result.return || (isDurableBinding && result.return != null)) {
+                    if (result.return) {
                         if (this._v1WorkerBehavior) {
                             response.returnValue = toTypedData(result.return);
                         } else {

--- a/test/WorkerChannelTests.ts
+++ b/test/WorkerChannelTests.ts
@@ -737,43 +737,34 @@ describe('WorkerChannel', () => {
             });
         });
 
-        it('returns and serializes falsy value in Durable: ""', () => {
+        it('returns null for falsy value in Durable: "" (legacy behavior)', () => {
             loader.getFunc.returns((context) => context.done(null, ''));
             loader.getInfo.returns(new FunctionInfo(activityBinding));
 
             sendInvokeMessage([], getHttpTriggerDataMock());
 
             const expectedOutput = [];
-            const expectedReturnValue = {
-                string: '',
-            };
-            assertInvocationSuccess(expectedOutput, expectedReturnValue);
+            assertInvocationSuccess(expectedOutput);
         });
 
-        it('returns and serializes falsy value in Durable: 0', () => {
+        it('returns null for falsy value in Durable: 0 (legacy behavior)', () => {
             loader.getFunc.returns((context) => context.done(null, 0));
             loader.getInfo.returns(new FunctionInfo(activityBinding));
 
             sendInvokeMessage([], getHttpTriggerDataMock());
 
             const expectedOutput = [];
-            const expectedReturnValue = {
-                int: 0,
-            };
-            assertInvocationSuccess(expectedOutput, expectedReturnValue);
+            assertInvocationSuccess(expectedOutput);
         });
 
-        it('returns and serializes falsy value in Durable: false', () => {
+        it('returns null for falsy value in Durable: false (legacy behavior)', () => {
             loader.getFunc.returns((context) => context.done(null, false));
             loader.getInfo.returns(new FunctionInfo(activityBinding));
 
             sendInvokeMessage([], getHttpTriggerDataMock());
 
             const expectedOutput = [];
-            const expectedReturnValue = {
-                json: 'false',
-            };
-            assertInvocationSuccess(expectedOutput, expectedReturnValue);
+            assertInvocationSuccess(expectedOutput);
         });
 
         it('logs AzureFiles cold start warning', async () => {


### PR DESCRIPTION
Reverts https://github.com/Azure/azure-functions-nodejs-worker/pull/383, which has never been released in the host for this major version. The reason we're reverting is because this could potentially break users who depend on the existing behavior. There was originally some discussion that this may be "worth it" for v2.x because of how incorrect the behavior was, but that discussion is somewhat moot now because people can migrate to v3.x of the worker which had this change from the start.