### PR TITLE
Move event handlers out of WorkerChannel

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "clean": "rimraf dist && rimraf azure-functions-language-worker-protobuf/src/rpc*",
         "build": "rimraf dist && npm run gen && shx mkdir -p dist/azure-functions-language-worker-protobuf/src && shx cp azure-functions-language-worker-protobuf/src/rpc.* dist/azure-functions-language-worker-protobuf/src/. && node ./node_modules/typescript/bin/tsc",
         "gen": "node scripts/generateProtos.js",
-        "test": "mocha -r ts-node/register ./test/**/*.ts --reporter mocha-multi-reporters --reporter-options configFile=test/mochaReporterOptions.json",
+        "test": "mocha -r ts-node/register \"./test/**/*.ts\" --reporter mocha-multi-reporters --reporter-options configFile=test/mochaReporterOptions.json",
         "lint": "eslint .",
         "lint-fix": "eslint . --fix",
         "watch": "node ./node_modules/typescript/bin/tsc --watch",

--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -2,12 +2,12 @@
 // Licensed under the MIT License.
 
 import { Context } from '@azure/functions';
-import { access, constants } from 'fs';
-import * as path from 'path';
-import { format } from 'util';
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
-import { CreateContextAndInputs, LogCallback, ResultCallback } from './Context';
-import { toTypedData } from './converters';
+import { functionEnvironmentReloadRequest } from './eventHandlers/functionEnvironmentReloadRequest';
+import { functionLoadRequest } from './eventHandlers/functionLoadRequest';
+import { invocationRequest } from './eventHandlers/invocationRequest';
+import { workerInitRequest } from './eventHandlers/workerInitRequest';
+import { workerStatusRequest } from './eventHandlers/workerStatusRequest';
 import { IFunctionLoader } from './FunctionLoader';
 import { IEventStream } from './GrpcClient';
 import { InternalException } from './utils/InternalException';
@@ -19,36 +19,20 @@ type InvocationRequestBefore = (context: Context, userFn: Function) => Function;
 type InvocationRequestAfter = (context: Context) => void;
 
 /**
+ * Initializes handlers for incoming gRPC messages on the client
+ *
  * The worker channel should have a way to handle all incoming gRPC messages.
  * This includes all incoming StreamingMessage types (exclude *Response types and RpcLog type)
  */
-interface IWorkerChannel {
-    startStream(requestId: string, msg: rpc.StartStream): void;
-    workerInitRequest(requestId: string, msg: rpc.WorkerInitRequest): void;
-    workerHeartbeat(requestId: string, msg: rpc.WorkerHeartbeat): void;
-    workerTerminate(requestId: string, msg: rpc.WorkerTerminate): void;
-    workerStatusRequest(requestId: string, msg: rpc.WorkerStatusRequest): void;
-    fileChangeEventRequest(requestId: string, msg: rpc.FileChangeEventRequest): void;
-    functionLoadRequest(requestId: string, msg: rpc.FunctionLoadRequest): void;
-    invocationRequest(requestId: string, msg: rpc.InvocationRequest): void;
-    invocationCancel(requestId: string, msg: rpc.InvocationCancel): void;
-    functionEnvironmentReloadRequest(requestId: string, msg: rpc.IFunctionEnvironmentReloadRequest): void;
-    registerBeforeInvocationRequest(beforeCb: InvocationRequestBefore): void;
-    registerAfterInvocationRequest(afterCb: InvocationRequestAfter): void;
-}
-
-/**
- * Initializes handlers for incoming gRPC messages on the client
- */
-export class WorkerChannel implements IWorkerChannel {
-    private _eventStream: IEventStream;
-    private _functionLoader: IFunctionLoader;
+export class WorkerChannel {
+    public eventStream: IEventStream;
+    public functionLoader: IFunctionLoader;
     private _invocationRequestBefore: InvocationRequestBefore[];
     private _invocationRequestAfter: InvocationRequestAfter[];
 
     constructor(workerId: string, eventStream: IEventStream, functionLoader: IFunctionLoader) {
-        this._eventStream = eventStream;
-        this._functionLoader = functionLoader;
+        this.eventStream = eventStream;
+        this.functionLoader = functionLoader;
         this._invocationRequestBefore = [];
         this._invocationRequestAfter = [];
 
@@ -88,8 +72,8 @@ export class WorkerChannel implements IWorkerChannel {
      * @param requestId gRPC message request id
      * @param msg gRPC message content
      */
-    private log(log: rpc.IRpcLog) {
-        this._eventStream.write({
+    public log(log: rpc.IRpcLog) {
+        this.eventStream.write({
             rpcLog: log,
         });
     }
@@ -115,52 +99,7 @@ export class WorkerChannel implements IWorkerChannel {
      * @param msg gRPC message content
      */
     public workerInitRequest(requestId: string, _msg: rpc.WorkerInitRequest) {
-        // Validate version
-        const version = process.version;
-        if (
-            (version.startsWith('v17.') || version.startsWith('v15.')) &&
-            process.env.AZURE_FUNCTIONS_ENVIRONMENT == 'Development'
-        ) {
-            const msg =
-                'Node.js version used (' +
-                version +
-                ') is not officially supported. You may use it during local development, but must use an officially supported version on Azure:' +
-                ' https://aka.ms/functions-node-versions';
-            this.log({
-                message: msg,
-                level: LogLevel.Warning,
-                logCategory: LogCategory.System,
-            });
-        } else if (!(version.startsWith('v14.') || version.startsWith('v16.'))) {
-            const msg =
-                'Incompatible Node.js version' +
-                ' (' +
-                version +
-                ').' +
-                ' The version of the Azure Functions runtime you are using (v4) supports Node.js v14.x or Node.js v16.x' +
-                ' Refer to our documentation to see the Node.js versions supported by each version of Azure Functions: https://aka.ms/functions-node-versions';
-            systemError(msg);
-            throw new InternalException(msg);
-        }
-
-        this.logColdStartWarning();
-
-        const workerCapabilities = {
-            RpcHttpTriggerMetadataRemoved: 'true',
-            RpcHttpBodyOnly: 'true',
-            IgnoreEmptyValuedRpcHttpHeaders: 'true',
-            UseNullableValueDictionaryForHttp: 'true',
-            WorkerStatus: 'true',
-            TypedDataCollection: 'true',
-        };
-
-        this._eventStream.write({
-            requestId: requestId,
-            workerInitResponse: {
-                result: this.getStatus(),
-                capabilities: workerCapabilities,
-            },
-        });
+        workerInitRequest(this, requestId, _msg);
     }
 
     /**
@@ -169,28 +108,7 @@ export class WorkerChannel implements IWorkerChannel {
      * @param msg gRPC message content
      */
     public async functionLoadRequest(requestId: string, msg: rpc.FunctionLoadRequest) {
-        if (msg.functionId && msg.metadata) {
-            let err, errorMessage;
-            try {
-                await this._functionLoader.load(msg.functionId, msg.metadata);
-            } catch (exception) {
-                errorMessage = `Worker was unable to load function ${msg.metadata.name}: '${exception}'`;
-                this.log({
-                    message: errorMessage,
-                    level: LogLevel.Error,
-                    logCategory: LogCategory.System,
-                });
-                err = exception;
-            }
-
-            this._eventStream.write({
-                requestId: requestId,
-                functionLoadResponse: {
-                    functionId: msg.functionId,
-                    result: this.getStatus(err, errorMessage),
-                },
-            });
-        }
+        await functionLoadRequest(this, requestId, msg);
     }
 
     /**
@@ -199,117 +117,7 @@ export class WorkerChannel implements IWorkerChannel {
      * @param msg gRPC message content
      */
     public invocationRequest(requestId: string, msg: rpc.InvocationRequest) {
-        const info = this._functionLoader.getInfo(msg.functionId);
-        const logCallback: LogCallback = (level, category, ...args) => {
-            this.log({
-                invocationId: msg.invocationId,
-                category: `${info.name}.Invocation`,
-                message: format.apply(null, <[any, any[]]>args),
-                level: level,
-                logCategory: category,
-            });
-        };
-
-        // Log invocation details to ensure the invocation received by node worker
-        logCallback(LogLevel.Debug, LogCategory.System, 'Received FunctionInvocationRequest');
-
-        const resultCallback: ResultCallback = (err, result) => {
-            const response: rpc.IInvocationResponse = {
-                invocationId: msg.invocationId,
-                result: this.getStatus(err),
-            };
-            // explicitly set outputData to empty array to concat later
-            response.outputData = [];
-
-            // As legacy behavior, falsy values get serialized to `null` in AzFunctions.
-            // This breaks Durable Functions expectations, where customers expect any
-            // JSON-serializable values to be preserved by the framework,
-            // so we check if we're serializing for durable and, if so, ensure falsy
-            // values get serialized.
-            const isDurableBinding = info?.bindings?.name?.type == 'activityTrigger';
-
-            try {
-                if (result || (isDurableBinding && result != null)) {
-                    const returnBinding = info.getReturnBinding();
-                    // Set results from return / context.done
-                    if (result.return || (isDurableBinding && result.return != null)) {
-                        // $return binding is found: return result data to $return binding
-                        if (returnBinding) {
-                            response.returnValue = returnBinding.converter(result.return);
-                            // $return binding is not found: read result as object of outputs
-                        } else {
-                            response.outputData = Object.keys(info.outputBindings)
-                                .filter((key) => result.return[key] !== undefined)
-                                .map(
-                                    (key) =>
-                                        <rpc.IParameterBinding>{
-                                            name: key,
-                                            data: info.outputBindings[key].converter(result.return[key]),
-                                        }
-                                );
-                        }
-                        // returned value does not match any output bindings (named or $return)
-                        // if not http, pass along value
-                        if (!response.returnValue && response.outputData.length == 0 && !info.hasHttpTrigger) {
-                            response.returnValue = toTypedData(result.return);
-                        }
-                    }
-                    // Set results from context.bindings
-                    if (result.bindings) {
-                        response.outputData = response.outputData.concat(
-                            Object.keys(info.outputBindings)
-                                // Data from return prioritized over data from context.bindings
-                                .filter((key) => {
-                                    const definedInBindings: boolean = result.bindings[key] !== undefined;
-                                    const hasReturnValue = !!result.return;
-                                    const hasReturnBinding = !!returnBinding;
-                                    const definedInReturn: boolean =
-                                        hasReturnValue && !hasReturnBinding && result.return[key] !== undefined;
-                                    return definedInBindings && !definedInReturn;
-                                })
-                                .map(
-                                    (key) =>
-                                        <rpc.IParameterBinding>{
-                                            name: key,
-                                            data: info.outputBindings[key].converter(result.bindings[key]),
-                                        }
-                                )
-                        );
-                    }
-                }
-            } catch (e) {
-                response.result = this.getStatus(e);
-            }
-            this._eventStream.write({
-                requestId: requestId,
-                invocationResponse: response,
-            });
-
-            this.runInvocationRequestAfter(context);
-        };
-
-        const { context, inputs } = CreateContextAndInputs(info, msg, logCallback, resultCallback);
-        let userFunction = this._functionLoader.getFunc(msg.functionId);
-
-        userFunction = this.runInvocationRequestBefore(context, userFunction);
-
-        // catch user errors from the same async context in the event loop and correlate with invocation
-        // throws from asynchronous work (setTimeout, etc) are caught by 'unhandledException' and cannot be correlated with invocation
-        try {
-            const result = userFunction(context, ...inputs);
-
-            if (result && typeof result.then === 'function') {
-                result
-                    .then((result) => {
-                        (<any>context.done)(null, result, true);
-                    })
-                    .catch((err) => {
-                        (<any>context.done)(err, null, true);
-                    });
-            }
-        } catch (err) {
-            resultCallback(err);
-        }
+        invocationRequest(this, requestId, msg);
     }
 
     /**
@@ -338,11 +146,7 @@ export class WorkerChannel implements IWorkerChannel {
      * Worker sends the host empty response to evaluate the worker's latency
      */
     public workerStatusRequest(requestId: string, _msg: rpc.WorkerStatusRequest): void {
-        const workerStatusResponse: rpc.IWorkerStatusResponse = {};
-        this._eventStream.write({
-            requestId: requestId,
-            workerStatusResponse,
-        });
+        workerStatusRequest(this, requestId, _msg);
     }
 
     /**
@@ -363,57 +167,10 @@ export class WorkerChannel implements IWorkerChannel {
      * Environment variables from the current process
      */
     public functionEnvironmentReloadRequest(requestId: string, msg: rpc.IFunctionEnvironmentReloadRequest): void {
-        // Add environment variables from incoming
-        const numVariables = (msg.environmentVariables && Object.keys(msg.environmentVariables).length) || 0;
-        this.log({
-            message: `Reloading environment variables. Found ${numVariables} variables to reload.`,
-            level: LogLevel.Information,
-            logCategory: LogCategory.System,
-        });
-
-        let error = null;
-        try {
-            process.env = Object.assign({}, msg.environmentVariables);
-            // Change current working directory
-            if (msg.functionAppDirectory) {
-                this.log({
-                    message: `Changing current working directory to ${msg.functionAppDirectory}`,
-                    level: LogLevel.Information,
-                    logCategory: LogCategory.System,
-                });
-                process.chdir(msg.functionAppDirectory);
-            }
-        } catch (e) {
-            error = e;
-        }
-
-        const functionEnvironmentReloadResponse: rpc.IFunctionEnvironmentReloadResponse = {
-            result: this.getStatus(error),
-        };
-
-        this._eventStream.write({
-            requestId: requestId,
-            functionEnvironmentReloadResponse,
-        });
+        functionEnvironmentReloadRequest(this, requestId, msg);
     }
 
-    private getStatus(err?: any, errorMessage?: string): rpc.IStatusResult {
-        const status: rpc.IStatusResult = {
-            status: rpc.StatusResult.Status.Success,
-        };
-
-        if (err) {
-            status.status = rpc.StatusResult.Status.Failure;
-            status.exception = {
-                message: errorMessage || err.toString(),
-                stackTrace: err.stack,
-            };
-        }
-
-        return status;
-    }
-
-    private runInvocationRequestBefore(context: Context, userFunction: Function): Function {
+    public runInvocationRequestBefore(context: Context, userFunction: Function): Function {
         let wrappedFunction = userFunction;
         for (const before of this._invocationRequestBefore) {
             wrappedFunction = before(context, wrappedFunction);
@@ -421,36 +178,9 @@ export class WorkerChannel implements IWorkerChannel {
         return wrappedFunction;
     }
 
-    private runInvocationRequestAfter(context: Context) {
+    public runInvocationRequestAfter(context: Context) {
         for (const after of this._invocationRequestAfter) {
             after(context);
-        }
-    }
-
-    private logColdStartWarning(delayInMs?: number): void {
-        // On reading a js file with function code('require') NodeJs tries to find 'package.json' all the way up to the file system root.
-        // In Azure files it causes a delay during cold start as connection to Azure Files is an expensive operation.
-        if (
-            process.env.WEBSITE_CONTENTAZUREFILECONNECTIONSTRING &&
-            process.env.WEBSITE_CONTENTSHARE &&
-            process.env.AzureWebJobsScriptRoot
-        ) {
-            // Add delay to avoid affecting coldstart
-            if (!delayInMs) {
-                delayInMs = 5000;
-            }
-            setTimeout(() => {
-                access(path.join(process.env.AzureWebJobsScriptRoot!, 'package.json'), constants.F_OK, (e) => {
-                    if (e) {
-                        this.log({
-                            message:
-                                'package.json is not found at the root of the Function App in Azure Files - cold start for NodeJs can be affected.',
-                            level: LogLevel.Debug,
-                            logCategory: LogCategory.System,
-                        });
-                    }
-                });
-            }, delayInMs);
         }
     }
 }

--- a/src/eventHandlers/functionEnvironmentReloadRequest.ts
+++ b/src/eventHandlers/functionEnvironmentReloadRequest.ts
@@ -1,0 +1,50 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
+import { toRpcStatus } from '../utils/toRpcStatus';
+import { WorkerChannel } from '../WorkerChannel';
+import LogCategory = rpc.RpcLog.RpcLogCategory;
+import LogLevel = rpc.RpcLog.Level;
+
+/**
+ * Environment variables from the current process
+ */
+export function functionEnvironmentReloadRequest(
+    channel: WorkerChannel,
+    requestId: string,
+    msg: rpc.IFunctionEnvironmentReloadRequest
+): void {
+    // Add environment variables from incoming
+    const numVariables = (msg.environmentVariables && Object.keys(msg.environmentVariables).length) || 0;
+    channel.log({
+        message: `Reloading environment variables. Found ${numVariables} variables to reload.`,
+        level: LogLevel.Information,
+        logCategory: LogCategory.System,
+    });
+
+    let error = null;
+    try {
+        process.env = Object.assign({}, msg.environmentVariables);
+        // Change current working directory
+        if (msg.functionAppDirectory) {
+            channel.log({
+                message: `Changing current working directory to ${msg.functionAppDirectory}`,
+                level: LogLevel.Information,
+                logCategory: LogCategory.System,
+            });
+            process.chdir(msg.functionAppDirectory);
+        }
+    } catch (e) {
+        error = e;
+    }
+
+    const functionEnvironmentReloadResponse: rpc.IFunctionEnvironmentReloadResponse = {
+        result: toRpcStatus(error),
+    };
+
+    channel.eventStream.write({
+        requestId: requestId,
+        functionEnvironmentReloadResponse,
+    });
+}

--- a/src/eventHandlers/functionLoadRequest.ts
+++ b/src/eventHandlers/functionLoadRequest.ts
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
+import { toRpcStatus } from '../utils/toRpcStatus';
+import { WorkerChannel } from '../WorkerChannel';
+import LogCategory = rpc.RpcLog.RpcLogCategory;
+import LogLevel = rpc.RpcLog.Level;
+
+/**
+ * Worker responds after loading required metadata to load function with the load result
+ * @param requestId gRPC message request id
+ * @param msg gRPC message content
+ */
+export async function functionLoadRequest(channel: WorkerChannel, requestId: string, msg: rpc.FunctionLoadRequest) {
+    if (msg.functionId && msg.metadata) {
+        let err, errorMessage;
+        try {
+            await channel.functionLoader.load(msg.functionId, msg.metadata);
+        } catch (exception) {
+            errorMessage = `Worker was unable to load function ${msg.metadata.name}: '${exception}'`;
+            channel.log({
+                message: errorMessage,
+                level: LogLevel.Error,
+                logCategory: LogCategory.System,
+            });
+            err = exception;
+        }
+
+        channel.eventStream.write({
+            requestId: requestId,
+            functionLoadResponse: {
+                functionId: msg.functionId,
+                result: toRpcStatus(err, errorMessage),
+            },
+        });
+    }
+}

--- a/src/eventHandlers/invocationRequest.ts
+++ b/src/eventHandlers/invocationRequest.ts
@@ -1,0 +1,130 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { format } from 'util';
+import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
+import { CreateContextAndInputs, LogCallback, ResultCallback } from '../Context';
+import { toTypedData } from '../converters';
+import { toRpcStatus } from '../utils/toRpcStatus';
+import { WorkerChannel } from '../WorkerChannel';
+import LogCategory = rpc.RpcLog.RpcLogCategory;
+import LogLevel = rpc.RpcLog.Level;
+
+/**
+ * Host requests worker to invoke a Function
+ * @param requestId gRPC message request id
+ * @param msg gRPC message content
+ */
+export function invocationRequest(channel: WorkerChannel, requestId: string, msg: rpc.InvocationRequest) {
+    const info = channel.functionLoader.getInfo(msg.functionId);
+    const logCallback: LogCallback = (level, category, ...args) => {
+        channel.log({
+            invocationId: msg.invocationId,
+            category: `${info.name}.Invocation`,
+            message: format.apply(null, <[any, any[]]>args),
+            level: level,
+            logCategory: category,
+        });
+    };
+
+    // Log invocation details to ensure the invocation received by node worker
+    logCallback(LogLevel.Debug, LogCategory.System, 'Received FunctionInvocationRequest');
+
+    const resultCallback: ResultCallback = (err, result) => {
+        const response: rpc.IInvocationResponse = {
+            invocationId: msg.invocationId,
+            result: toRpcStatus(err),
+        };
+        // explicitly set outputData to empty array to concat later
+        response.outputData = [];
+
+        // As legacy behavior, falsy values get serialized to `null` in AzFunctions.
+        // This breaks Durable Functions expectations, where customers expect any
+        // JSON-serializable values to be preserved by the framework,
+        // so we check if we're serializing for durable and, if so, ensure falsy
+        // values get serialized.
+        const isDurableBinding = info?.bindings?.name?.type == 'activityTrigger';
+
+        try {
+            if (result || (isDurableBinding && result != null)) {
+                const returnBinding = info.getReturnBinding();
+                // Set results from return / context.done
+                if (result.return || (isDurableBinding && result.return != null)) {
+                    // $return binding is found: return result data to $return binding
+                    if (returnBinding) {
+                        response.returnValue = returnBinding.converter(result.return);
+                        // $return binding is not found: read result as object of outputs
+                    } else {
+                        response.outputData = Object.keys(info.outputBindings)
+                            .filter((key) => result.return[key] !== undefined)
+                            .map(
+                                (key) =>
+                                    <rpc.IParameterBinding>{
+                                        name: key,
+                                        data: info.outputBindings[key].converter(result.return[key]),
+                                    }
+                            );
+                    }
+                    // returned value does not match any output bindings (named or $return)
+                    // if not http, pass along value
+                    if (!response.returnValue && response.outputData.length == 0 && !info.hasHttpTrigger) {
+                        response.returnValue = toTypedData(result.return);
+                    }
+                }
+                // Set results from context.bindings
+                if (result.bindings) {
+                    response.outputData = response.outputData.concat(
+                        Object.keys(info.outputBindings)
+                            // Data from return prioritized over data from context.bindings
+                            .filter((key) => {
+                                const definedInBindings: boolean = result.bindings[key] !== undefined;
+                                const hasReturnValue = !!result.return;
+                                const hasReturnBinding = !!returnBinding;
+                                const definedInReturn: boolean =
+                                    hasReturnValue && !hasReturnBinding && result.return[key] !== undefined;
+                                return definedInBindings && !definedInReturn;
+                            })
+                            .map(
+                                (key) =>
+                                    <rpc.IParameterBinding>{
+                                        name: key,
+                                        data: info.outputBindings[key].converter(result.bindings[key]),
+                                    }
+                            )
+                    );
+                }
+            }
+        } catch (e) {
+            response.result = toRpcStatus(e);
+        }
+        channel.eventStream.write({
+            requestId: requestId,
+            invocationResponse: response,
+        });
+
+        channel.runInvocationRequestAfter(context);
+    };
+
+    const { context, inputs } = CreateContextAndInputs(info, msg, logCallback, resultCallback);
+    let userFunction = channel.functionLoader.getFunc(msg.functionId);
+
+    userFunction = channel.runInvocationRequestBefore(context, userFunction);
+
+    // catch user errors from the same async context in the event loop and correlate with invocation
+    // throws from asynchronous work (setTimeout, etc) are caught by 'unhandledException' and cannot be correlated with invocation
+    try {
+        const result = userFunction(context, ...inputs);
+
+        if (result && typeof result.then === 'function') {
+            result
+                .then((result) => {
+                    (<any>context.done)(null, result, true);
+                })
+                .catch((err) => {
+                    (<any>context.done)(err, null, true);
+                });
+        }
+    } catch (err) {
+        resultCallback(err);
+    }
+}

--- a/src/eventHandlers/workerInitRequest.ts
+++ b/src/eventHandlers/workerInitRequest.ts
@@ -1,0 +1,93 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { access, constants } from 'fs';
+import * as path from 'path';
+import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
+import { InternalException } from '../utils/InternalException';
+import { systemError } from '../utils/Logger';
+import { toRpcStatus } from '../utils/toRpcStatus';
+import { WorkerChannel } from '../WorkerChannel';
+import LogCategory = rpc.RpcLog.RpcLogCategory;
+import LogLevel = rpc.RpcLog.Level;
+
+/**
+ * Host sends capabilities/init data to worker and requests the worker to initialize itself
+ * @param requestId gRPC message request id
+ * @param msg gRPC message content
+ */
+export function workerInitRequest(channel: WorkerChannel, requestId: string, _msg: rpc.WorkerInitRequest) {
+    // Validate version
+    const version = process.version;
+    if (
+        (version.startsWith('v17.') || version.startsWith('v15.')) &&
+        process.env.AZURE_FUNCTIONS_ENVIRONMENT == 'Development'
+    ) {
+        const msg =
+            'Node.js version used (' +
+            version +
+            ') is not officially supported. You may use it during local development, but must use an officially supported version on Azure:' +
+            ' https://aka.ms/functions-node-versions';
+        channel.log({
+            message: msg,
+            level: LogLevel.Warning,
+            logCategory: LogCategory.System,
+        });
+    } else if (!(version.startsWith('v14.') || version.startsWith('v16.'))) {
+        const msg =
+            'Incompatible Node.js version' +
+            ' (' +
+            version +
+            ').' +
+            ' The version of the Azure Functions runtime you are using (v4) supports Node.js v14.x or Node.js v16.x' +
+            ' Refer to our documentation to see the Node.js versions supported by each version of Azure Functions: https://aka.ms/functions-node-versions';
+        systemError(msg);
+        throw new InternalException(msg);
+    }
+
+    logColdStartWarning(channel);
+
+    const workerCapabilities = {
+        RpcHttpTriggerMetadataRemoved: 'true',
+        RpcHttpBodyOnly: 'true',
+        IgnoreEmptyValuedRpcHttpHeaders: 'true',
+        UseNullableValueDictionaryForHttp: 'true',
+        WorkerStatus: 'true',
+        TypedDataCollection: 'true',
+    };
+
+    channel.eventStream.write({
+        requestId: requestId,
+        workerInitResponse: {
+            result: toRpcStatus(),
+            capabilities: workerCapabilities,
+        },
+    });
+}
+
+export function logColdStartWarning(channel: WorkerChannel, delayInMs?: number): void {
+    // On reading a js file with function code('require') NodeJs tries to find 'package.json' all the way up to the file system root.
+    // In Azure files it causes a delay during cold start as connection to Azure Files is an expensive operation.
+    if (
+        process.env.WEBSITE_CONTENTAZUREFILECONNECTIONSTRING &&
+        process.env.WEBSITE_CONTENTSHARE &&
+        process.env.AzureWebJobsScriptRoot
+    ) {
+        // Add delay to avoid affecting coldstart
+        if (!delayInMs) {
+            delayInMs = 5000;
+        }
+        setTimeout(() => {
+            access(path.join(process.env.AzureWebJobsScriptRoot!, 'package.json'), constants.F_OK, (e) => {
+                if (e) {
+                    channel.log({
+                        message:
+                            'package.json is not found at the root of the Function App in Azure Files - cold start for NodeJs can be affected.',
+                        level: LogLevel.Debug,
+                        logCategory: LogCategory.System,
+                    });
+                }
+            });
+        }, delayInMs);
+    }
+}

--- a/src/eventHandlers/workerStatusRequest.ts
+++ b/src/eventHandlers/workerStatusRequest.ts
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
+import { WorkerChannel } from '../WorkerChannel';
+
+/**
+ * Worker sends the host empty response to evaluate the worker's latency
+ */
+export function workerStatusRequest(channel: WorkerChannel, requestId: string, _msg: rpc.WorkerStatusRequest): void {
+    const workerStatusResponse: rpc.IWorkerStatusResponse = {};
+    channel.eventStream.write({
+        requestId: requestId,
+        workerStatusResponse,
+    });
+}

--- a/src/utils/toRpcStatus.ts
+++ b/src/utils/toRpcStatus.ts
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
+
+export function toRpcStatus(err?: any, errorMessage?: string): rpc.IStatusResult {
+    const status: rpc.IStatusResult = {
+        status: rpc.StatusResult.Status.Success,
+    };
+
+    if (err) {
+        status.status = rpc.StatusResult.Status.Failure;
+        status.exception = {
+            message: errorMessage || err.toString(),
+            stackTrace: err.stack,
+        };
+    }
+
+    return status;
+}

--- a/test/eventHandlers/TestEventStream.ts
+++ b/test/eventHandlers/TestEventStream.ts
@@ -3,8 +3,8 @@
 
 import { EventEmitter } from 'events';
 import * as sinon from 'sinon';
-import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
-import { IEventStream } from '../src/GrpcClient';
+import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
+import { IEventStream } from '../../src/GrpcClient';
 
 export class TestEventStream extends EventEmitter implements IEventStream {
     written: sinon.SinonSpy;

--- a/test/eventHandlers/beforeEventHandlerTest.ts
+++ b/test/eventHandlers/beforeEventHandlerTest.ts
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as sinon from 'sinon';
+import { FunctionLoader } from '../../src/FunctionLoader';
+import { WorkerChannel } from '../../src/WorkerChannel';
+import { TestEventStream } from './TestEventStream';
+
+export function beforeEventHandlerTest() {
+    const stream = new TestEventStream();
+    const loader = sinon.createStubInstance<FunctionLoader>(FunctionLoader);
+    const channel = new WorkerChannel('workerId', stream, loader);
+    return { stream, loader, channel };
+}

--- a/test/eventHandlers/functionEnvironmentReloadRequest.test.ts
+++ b/test/eventHandlers/functionEnvironmentReloadRequest.test.ts
@@ -1,0 +1,155 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { expect } from 'chai';
+import 'mocha';
+import * as sinon from 'sinon';
+import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
+import { beforeEventHandlerTest } from './beforeEventHandlerTest';
+import { TestEventStream } from './TestEventStream';
+
+describe('functionEnvironmentReloadRequest', () => {
+    let stream: TestEventStream;
+
+    // Reset `process.env` after this test suite so it doesn't affect other tests
+    let originalEnv: NodeJS.ProcessEnv;
+    before(() => {
+        originalEnv = process.env;
+    });
+
+    after(() => {
+        process.env = originalEnv;
+    });
+
+    beforeEach(() => {
+        ({ stream } = beforeEventHandlerTest());
+    });
+
+    it('reloads environment variables', () => {
+        process.env.PlaceholderVariable = 'TRUE';
+        stream.addTestMessage({
+            requestId: 'id',
+            functionEnvironmentReloadRequest: {
+                environmentVariables: {
+                    hello: 'world',
+                    SystemDrive: 'Q:',
+                },
+                functionAppDirectory: null,
+            },
+        });
+        sinon.assert.calledWith(stream.written, <rpc.IStreamingMessage>{
+            requestId: 'id',
+            functionEnvironmentReloadResponse: {
+                result: {
+                    status: rpc.StatusResult.Status.Success,
+                },
+            },
+        });
+        expect(process.env.hello).to.equal('world');
+        expect(process.env.SystemDrive).to.equal('Q:');
+        expect(process.env.PlaceholderVariable).to.be.undefined;
+    });
+
+    it('reloading environment variables removes existing environment variables', () => {
+        process.env.PlaceholderVariable = 'TRUE';
+        process.env.NODE_ENV = 'Debug';
+        stream.addTestMessage({
+            requestId: 'id',
+            functionEnvironmentReloadRequest: {
+                environmentVariables: {},
+                functionAppDirectory: null,
+            },
+        });
+        sinon.assert.calledWith(stream.written, <rpc.IStreamingMessage>{
+            requestId: 'id',
+            functionEnvironmentReloadResponse: {
+                result: {
+                    status: rpc.StatusResult.Status.Success,
+                },
+            },
+        });
+        expect(process.env).to.be.empty;
+    });
+
+    it('reloads empty environment variables without throwing', () => {
+        expect(() => {
+            stream.write({
+                requestId: 'id',
+                functionEnvironmentReloadRequest: {
+                    environmentVariables: {},
+                    functionAppDirectory: null,
+                },
+            });
+        }).to.not.throw();
+
+        expect(() => {
+            stream.write({
+                requestId: 'id',
+                functionEnvironmentReloadRequest: null,
+            });
+        }).to.not.throw();
+
+        expect(() => {
+            stream.write({
+                requestId: 'id',
+                functionEnvironmentReloadRequest: {
+                    environmentVariables: null,
+                    functionAppDirectory: null,
+                },
+            });
+        }).to.not.throw();
+    });
+
+    it('reloads environment variable and keeps cwd without functionAppDirectory', () => {
+        const cwd = process.cwd();
+        stream.addTestMessage({
+            requestId: 'id',
+            functionEnvironmentReloadRequest: {
+                environmentVariables: {
+                    hello: 'world',
+                    SystemDrive: 'Q:',
+                },
+                functionAppDirectory: null,
+            },
+        });
+        sinon.assert.calledWith(stream.written, <rpc.IStreamingMessage>{
+            requestId: 'id',
+            functionEnvironmentReloadResponse: {
+                result: {
+                    status: rpc.StatusResult.Status.Success,
+                },
+            },
+        });
+        expect(process.env.hello).to.equal('world');
+        expect(process.env.SystemDrive).to.equal('Q:');
+        expect(process.cwd() == cwd);
+    });
+
+    it('reloads environment variable and changes functionAppDirectory', () => {
+        const cwd = process.cwd();
+        const newDir = '/';
+        stream.addTestMessage({
+            requestId: 'id',
+            functionEnvironmentReloadRequest: {
+                environmentVariables: {
+                    hello: 'world',
+                    SystemDrive: 'Q:',
+                },
+                functionAppDirectory: newDir,
+            },
+        });
+        sinon.assert.calledWith(stream.written, <rpc.IStreamingMessage>{
+            requestId: 'id',
+            functionEnvironmentReloadResponse: {
+                result: {
+                    status: rpc.StatusResult.Status.Success,
+                },
+            },
+        });
+        expect(process.env.hello).to.equal('world');
+        expect(process.env.SystemDrive).to.equal('Q:');
+        expect(process.cwd() != newDir);
+        expect(process.cwd() == newDir);
+        process.chdir(cwd);
+    });
+});

--- a/test/eventHandlers/functionLoadRequest.test.ts
+++ b/test/eventHandlers/functionLoadRequest.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'mocha';
+import * as sinon from 'sinon';
+import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
+import { FunctionLoader } from '../../src/FunctionLoader';
+import { WorkerChannel } from '../../src/WorkerChannel';
+import { beforeEventHandlerTest } from './beforeEventHandlerTest';
+import { TestEventStream } from './TestEventStream';
+
+describe('functionLoadRequest', () => {
+    let stream: TestEventStream;
+    let loader: sinon.SinonStubbedInstance<FunctionLoader>;
+
+    beforeEach(() => {
+        ({ stream, loader } = beforeEventHandlerTest());
+    });
+
+    it('responds to function load', async () => {
+        stream.addTestMessage({
+            requestId: 'id',
+            functionLoadRequest: {
+                functionId: 'funcId',
+                metadata: {},
+            },
+        });
+        // Set slight delay
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        sinon.assert.calledWith(stream.written, <rpc.IStreamingMessage>{
+            requestId: 'id',
+            functionLoadResponse: {
+                functionId: 'funcId',
+                result: {
+                    status: rpc.StatusResult.Status.Success,
+                },
+            },
+        });
+    });
+
+    it('handles function load exception', () => {
+        const err = new Error('Function throws error');
+        err.stack = '<STACKTRACE>';
+
+        loader.load = sinon.stub().throws(err);
+        new WorkerChannel('workerId', stream, loader);
+        stream.addTestMessage({
+            requestId: 'id',
+            functionLoadRequest: {
+                functionId: 'funcId',
+                metadata: {},
+            },
+        });
+        sinon.assert.calledWith(stream.written, <rpc.IStreamingMessage>{
+            requestId: 'id',
+            functionLoadResponse: {
+                functionId: 'funcId',
+                result: {
+                    status: rpc.StatusResult.Status.Failure,
+                    exception: {
+                        message: "Worker was unable to load function undefined: 'Error: Function throws error'",
+                        stackTrace: '<STACKTRACE>',
+                    },
+                },
+            },
+        });
+    });
+});

--- a/test/eventHandlers/invocationRequest.test.ts
+++ b/test/eventHandlers/invocationRequest.test.ts
@@ -4,18 +4,23 @@
 import { expect } from 'chai';
 import 'mocha';
 import * as sinon from 'sinon';
-import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
-import { FunctionInfo } from '../src/FunctionInfo';
-import { FunctionLoader } from '../src/FunctionLoader';
-import { WorkerChannel } from '../src/WorkerChannel';
+import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
+import { FunctionInfo } from '../../src/FunctionInfo';
+import { FunctionLoader } from '../../src/FunctionLoader';
+import { WorkerChannel } from '../../src/WorkerChannel';
+import { beforeEventHandlerTest } from './beforeEventHandlerTest';
 import { TestEventStream } from './TestEventStream';
 import LogCategory = rpc.RpcLog.RpcLogCategory;
 import LogLevel = rpc.RpcLog.Level;
 
-describe('WorkerChannel', () => {
+describe('invocationRequest', () => {
     let channel: WorkerChannel;
     let stream: TestEventStream;
     let loader: sinon.SinonStubbedInstance<FunctionLoader>;
+
+    beforeEach(() => {
+        ({ stream, loader, channel } = beforeEventHandlerTest());
+    });
 
     const sendInvokeMessage = (
         inputData?: rpc.IParameterBinding[] | null,
@@ -139,234 +144,6 @@ describe('WorkerChannel', () => {
             },
         },
     };
-
-    beforeEach(() => {
-        stream = new TestEventStream();
-        loader = sinon.createStubInstance<FunctionLoader>(FunctionLoader);
-        channel = new WorkerChannel('workerId', stream, loader);
-    });
-
-    it('responds to init', () => {
-        const initMessage = {
-            requestId: 'id',
-            workerInitRequest: {
-                capabilities: {},
-            },
-        };
-
-        const expectedOutput = {
-            requestId: 'id',
-            workerInitResponse: {
-                capabilities: {
-                    RpcHttpBodyOnly: 'true',
-                    RpcHttpTriggerMetadataRemoved: 'true',
-                    IgnoreEmptyValuedRpcHttpHeaders: 'true',
-                    UseNullableValueDictionaryForHttp: 'true',
-                },
-                result: {
-                    status: rpc.StatusResult.Status.Success,
-                },
-            },
-        };
-
-        expectedOutput.workerInitResponse.capabilities['TypedDataCollection'] = 'true';
-
-        stream.addTestMessage(initMessage);
-        sinon.assert.calledWith(stream.written);
-    });
-
-    it('does not init for Node.js v8.x and v2 compatability = false', () => {
-        const version = process.version;
-        if (version.split('.')[0] === 'v8') {
-            const initMessage = {
-                requestId: 'id',
-                workerInitRequest: {
-                    capabilities: {},
-                },
-            };
-
-            expect(() => stream.addTestMessage(initMessage)).to.throw(
-                `Incompatible Node.js version (${process.version}). The version of the Azure Functions runtime you are using (v3) supports Node.js v10.x and v12.x. Refer to our documentation to see the Node.js versions supported by each version of Azure Functions: https://aka.ms/functions-node-versions`
-            );
-        }
-    });
-
-    it('responds to function load', async () => {
-        stream.addTestMessage({
-            requestId: 'id',
-            functionLoadRequest: {
-                functionId: 'funcId',
-                metadata: {},
-            },
-        });
-        // Set slight delay
-        await new Promise((resolve) => setTimeout(resolve, 100));
-        sinon.assert.calledWith(stream.written, <rpc.IStreamingMessage>{
-            requestId: 'id',
-            functionLoadResponse: {
-                functionId: 'funcId',
-                result: {
-                    status: rpc.StatusResult.Status.Success,
-                },
-            },
-        });
-    });
-
-    it('handles function load exception', () => {
-        const err = new Error('Function throws error');
-        err.stack = '<STACKTRACE>';
-
-        loader.load = sinon.stub().throws(err);
-        channel = new WorkerChannel('workerId', stream, loader);
-        stream.addTestMessage({
-            requestId: 'id',
-            functionLoadRequest: {
-                functionId: 'funcId',
-                metadata: {},
-            },
-        });
-        sinon.assert.calledWith(stream.written, <rpc.IStreamingMessage>{
-            requestId: 'id',
-            functionLoadResponse: {
-                functionId: 'funcId',
-                result: {
-                    status: rpc.StatusResult.Status.Failure,
-                    exception: {
-                        message: "Worker was unable to load function undefined: 'Error: Function throws error'",
-                        stackTrace: '<STACKTRACE>',
-                    },
-                },
-            },
-        });
-    });
-
-    it('reloads environment variables', () => {
-        process.env.PlaceholderVariable = 'TRUE';
-        stream.addTestMessage({
-            requestId: 'id',
-            functionEnvironmentReloadRequest: {
-                environmentVariables: {
-                    hello: 'world',
-                    SystemDrive: 'Q:',
-                },
-                functionAppDirectory: null,
-            },
-        });
-        sinon.assert.calledWith(stream.written, <rpc.IStreamingMessage>{
-            requestId: 'id',
-            functionEnvironmentReloadResponse: {
-                result: {
-                    status: rpc.StatusResult.Status.Success,
-                },
-            },
-        });
-        expect(process.env.hello).to.equal('world');
-        expect(process.env.SystemDrive).to.equal('Q:');
-        expect(process.env.PlaceholderVariable).to.be.undefined;
-    });
-
-    it('reloading environment variables removes existing environment variables', () => {
-        process.env.PlaceholderVariable = 'TRUE';
-        process.env.NODE_ENV = 'Debug';
-        stream.addTestMessage({
-            requestId: 'id',
-            functionEnvironmentReloadRequest: {
-                environmentVariables: {},
-                functionAppDirectory: null,
-            },
-        });
-        sinon.assert.calledWith(stream.written, <rpc.IStreamingMessage>{
-            requestId: 'id',
-            functionEnvironmentReloadResponse: {
-                result: {
-                    status: rpc.StatusResult.Status.Success,
-                },
-            },
-        });
-        expect(process.env).to.be.empty;
-    });
-
-    it('reloads empty environment variables without throwing', () => {
-        expect(() => {
-            stream.write({
-                requestId: 'id',
-                functionEnvironmentReloadRequest: {
-                    environmentVariables: {},
-                    functionAppDirectory: null,
-                },
-            });
-        }).to.not.throw();
-
-        expect(() => {
-            stream.write({
-                requestId: 'id',
-                functionEnvironmentReloadRequest: null,
-            });
-        }).to.not.throw();
-
-        expect(() => {
-            stream.write({
-                requestId: 'id',
-                functionEnvironmentReloadRequest: {
-                    environmentVariables: null,
-                    functionAppDirectory: null,
-                },
-            });
-        }).to.not.throw();
-    });
-
-    it('reloads environment variable and keeps cwd without functionAppDirectory', () => {
-        const cwd = process.cwd();
-        stream.addTestMessage({
-            requestId: 'id',
-            functionEnvironmentReloadRequest: {
-                environmentVariables: {
-                    hello: 'world',
-                    SystemDrive: 'Q:',
-                },
-                functionAppDirectory: null,
-            },
-        });
-        sinon.assert.calledWith(stream.written, <rpc.IStreamingMessage>{
-            requestId: 'id',
-            functionEnvironmentReloadResponse: {
-                result: {
-                    status: rpc.StatusResult.Status.Success,
-                },
-            },
-        });
-        expect(process.env.hello).to.equal('world');
-        expect(process.env.SystemDrive).to.equal('Q:');
-        expect(process.cwd() == cwd);
-    });
-
-    it('reloads environment variable and changes functionAppDirectory', () => {
-        const cwd = process.cwd();
-        const newDir = '/';
-        stream.addTestMessage({
-            requestId: 'id',
-            functionEnvironmentReloadRequest: {
-                environmentVariables: {
-                    hello: 'world',
-                    SystemDrive: 'Q:',
-                },
-                functionAppDirectory: newDir,
-            },
-        });
-        sinon.assert.calledWith(stream.written, <rpc.IStreamingMessage>{
-            requestId: 'id',
-            functionEnvironmentReloadResponse: {
-                result: {
-                    status: rpc.StatusResult.Status.Success,
-                },
-            },
-        });
-        expect(process.env.hello).to.equal('world');
-        expect(process.env.SystemDrive).to.equal('Q:');
-        expect(process.cwd() != newDir);
-        expect(process.cwd() == newDir);
-        process.chdir(cwd);
-    });
 
     it('invokes function', () => {
         loader.getFunc.returns((context) => context.done());
@@ -621,77 +398,44 @@ describe('WorkerChannel', () => {
 
             sendInvokeMessage([httpInputData], getHttpTriggerDataMock());
         });
+    });
 
-        it('responds to worker status', async () => {
-            stream.addTestMessage({
-                requestId: 'id',
-                workerStatusRequest: {},
-            });
-            // Set slight delay
-            await new Promise((resolve) => setTimeout(resolve, 100));
-            sinon.assert.calledWith(stream.written, <rpc.IStreamingMessage>{
-                requestId: 'id',
-                workerStatusResponse: {},
-            });
-        });
+    it('returns and serializes falsy value in Durable: ""', () => {
+        loader.getFunc.returns((context) => context.done(null, ''));
+        loader.getInfo.returns(new FunctionInfo(activityBinding));
 
-        it('returns and serializes falsy value in Durable: ""', () => {
-            loader.getFunc.returns((context) => context.done(null, ''));
-            loader.getInfo.returns(new FunctionInfo(activityBinding));
+        sendInvokeMessage([], getHttpTriggerDataMock());
 
-            sendInvokeMessage([], getHttpTriggerDataMock());
+        const expectedOutput = [];
+        const expectedReturnValue = {
+            string: '',
+        };
+        assertInvocationSuccess(expectedOutput, expectedReturnValue);
+    });
 
-            const expectedOutput = [];
-            const expectedReturnValue = {
-                string: '',
-            };
-            assertInvocationSuccess(expectedOutput, expectedReturnValue);
-        });
+    it('returns and serializes falsy value in Durable: 0', () => {
+        loader.getFunc.returns((context) => context.done(null, 0));
+        loader.getInfo.returns(new FunctionInfo(activityBinding));
 
-        it('returns and serializes falsy value in Durable: 0', () => {
-            loader.getFunc.returns((context) => context.done(null, 0));
-            loader.getInfo.returns(new FunctionInfo(activityBinding));
+        sendInvokeMessage([], getHttpTriggerDataMock());
 
-            sendInvokeMessage([], getHttpTriggerDataMock());
+        const expectedOutput = [];
+        const expectedReturnValue = {
+            int: 0,
+        };
+        assertInvocationSuccess(expectedOutput, expectedReturnValue);
+    });
 
-            const expectedOutput = [];
-            const expectedReturnValue = {
-                int: 0,
-            };
-            assertInvocationSuccess(expectedOutput, expectedReturnValue);
-        });
+    it('returns and serializes falsy value in Durable: false', () => {
+        loader.getFunc.returns((context) => context.done(null, false));
+        loader.getInfo.returns(new FunctionInfo(activityBinding));
 
-        it('returns and serializes falsy value in Durable: false', () => {
-            loader.getFunc.returns((context) => context.done(null, false));
-            loader.getInfo.returns(new FunctionInfo(activityBinding));
+        sendInvokeMessage([], getHttpTriggerDataMock());
 
-            sendInvokeMessage([], getHttpTriggerDataMock());
-
-            const expectedOutput = [];
-            const expectedReturnValue = {
-                json: 'false',
-            };
-            assertInvocationSuccess(expectedOutput, expectedReturnValue);
-        });
-
-        it('logs AzureFiles cold start warning', async () => {
-            process.env.WEBSITE_CONTENTAZUREFILECONNECTIONSTRING = 'test';
-            process.env.WEBSITE_CONTENTSHARE = 'test';
-            process.env.AzureWebJobsScriptRoot = 'test';
-
-            // Accesing private method
-            (channel as any).logColdStartWarning(10);
-
-            // Set slight delay
-            await new Promise((resolve) => setTimeout(resolve, 1000));
-            sinon.assert.calledWith(stream.written, <rpc.IStreamingMessage>{
-                rpcLog: {
-                    message:
-                        'package.json is not found at the root of the Function App in Azure Files - cold start for NodeJs can be affected.',
-                    level: LogLevel.Debug,
-                    logCategory: LogCategory.System,
-                },
-            });
-        });
+        const expectedOutput = [];
+        const expectedReturnValue = {
+            json: 'false',
+        };
+        assertInvocationSuccess(expectedOutput, expectedReturnValue);
     });
 });

--- a/test/eventHandlers/workerInitRequest.test.ts
+++ b/test/eventHandlers/workerInitRequest.test.ts
@@ -1,0 +1,86 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { expect } from 'chai';
+import 'mocha';
+import * as sinon from 'sinon';
+import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
+import { logColdStartWarning } from '../../src/eventHandlers/workerInitRequest';
+import { WorkerChannel } from '../../src/WorkerChannel';
+import { beforeEventHandlerTest } from './beforeEventHandlerTest';
+import { TestEventStream } from './TestEventStream';
+import LogCategory = rpc.RpcLog.RpcLogCategory;
+import LogLevel = rpc.RpcLog.Level;
+
+describe('workerInitRequest', () => {
+    let channel: WorkerChannel;
+    let stream: TestEventStream;
+
+    beforeEach(() => {
+        ({ stream, channel } = beforeEventHandlerTest());
+    });
+
+    it('responds to init', () => {
+        const initMessage = {
+            requestId: 'id',
+            workerInitRequest: {
+                capabilities: {},
+            },
+        };
+
+        const expectedOutput = {
+            requestId: 'id',
+            workerInitResponse: {
+                capabilities: {
+                    RpcHttpBodyOnly: 'true',
+                    RpcHttpTriggerMetadataRemoved: 'true',
+                    IgnoreEmptyValuedRpcHttpHeaders: 'true',
+                    UseNullableValueDictionaryForHttp: 'true',
+                },
+                result: {
+                    status: rpc.StatusResult.Status.Success,
+                },
+            },
+        };
+
+        expectedOutput.workerInitResponse.capabilities['TypedDataCollection'] = 'true';
+
+        stream.addTestMessage(initMessage);
+        sinon.assert.calledWith(stream.written);
+    });
+
+    it('does not init for Node.js v8.x and v2 compatability = false', () => {
+        const version = process.version;
+        if (version.split('.')[0] === 'v8') {
+            const initMessage = {
+                requestId: 'id',
+                workerInitRequest: {
+                    capabilities: {},
+                },
+            };
+
+            expect(() => stream.addTestMessage(initMessage)).to.throw(
+                `Incompatible Node.js version (${process.version}). The version of the Azure Functions runtime you are using (v3) supports Node.js v10.x and v12.x. Refer to our documentation to see the Node.js versions supported by each version of Azure Functions: https://aka.ms/functions-node-versions`
+            );
+        }
+    });
+
+    it('logs AzureFiles cold start warning', async () => {
+        process.env.WEBSITE_CONTENTAZUREFILECONNECTIONSTRING = 'test';
+        process.env.WEBSITE_CONTENTSHARE = 'test';
+        process.env.AzureWebJobsScriptRoot = 'test';
+
+        logColdStartWarning(channel, 10);
+
+        // Set slight delay
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        sinon.assert.calledWith(stream.written, <rpc.IStreamingMessage>{
+            rpcLog: {
+                message:
+                    'package.json is not found at the root of the Function App in Azure Files - cold start for NodeJs can be affected.',
+                level: LogLevel.Debug,
+                logCategory: LogCategory.System,
+            },
+        });
+    });
+});

--- a/test/eventHandlers/workerStatusRequest.test.ts
+++ b/test/eventHandlers/workerStatusRequest.test.ts
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'mocha';
+import * as sinon from 'sinon';
+import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
+import { beforeEventHandlerTest } from './beforeEventHandlerTest';
+import { TestEventStream } from './TestEventStream';
+
+describe('workerStatusRequest', () => {
+    let stream: TestEventStream;
+
+    beforeEach(() => {
+        ({ stream } = beforeEventHandlerTest());
+    });
+
+    it('responds to worker status', async () => {
+        stream.addTestMessage({
+            requestId: 'id',
+            workerStatusRequest: {},
+        });
+        // Set slight delay
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        sinon.assert.calledWith(stream.written, <rpc.IStreamingMessage>{
+            requestId: 'id',
+            workerStatusResponse: {},
+        });
+    });
+});


### PR DESCRIPTION
`WorkerChannel.ts` and `WorkerChannelTests.ts` are both pretty chonky files and they're only going to continue growing. As a first step in improving this, I've pulled each "event handler" into its own file.

No functional changes, just moving code.