### PR TITLE
Move event stream setup out of WorkerChannel

### DIFF
--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -4,10 +4,10 @@
 import * as parseArgs from 'minimist';
 import { FunctionLoader } from './FunctionLoader';
 import { CreateGrpcEventStream } from './GrpcClient';
+import { setupEventStream } from './setupEventStream';
 import { ensureErrorType } from './utils/ensureErrorType';
 import { InternalException } from './utils/InternalException';
 import { systemError, systemLog } from './utils/Logger';
-import { WorkerChannel } from './WorkerChannel';
 
 export function startNodeWorker(args) {
     const { host, port, workerId, requestId, grpcMaxMessageLength } = parseArgs(args.slice(2));
@@ -39,7 +39,7 @@ export function startNodeWorker(args) {
         throw error;
     }
 
-    new WorkerChannel(workerId, eventStream, new FunctionLoader());
+    setupEventStream(workerId, eventStream, new FunctionLoader());
 
     eventStream.write({
         requestId: requestId,

--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -8,6 +8,7 @@ import { setupEventStream } from './setupEventStream';
 import { ensureErrorType } from './utils/ensureErrorType';
 import { InternalException } from './utils/InternalException';
 import { systemError, systemLog } from './utils/Logger';
+import { WorkerChannel } from './WorkerChannel';
 
 export function startNodeWorker(args) {
     const { host, port, workerId, requestId, grpcMaxMessageLength } = parseArgs(args.slice(2));
@@ -39,7 +40,8 @@ export function startNodeWorker(args) {
         throw error;
     }
 
-    setupEventStream(workerId, eventStream, new FunctionLoader());
+    const channel = new WorkerChannel(eventStream, new FunctionLoader());
+    setupEventStream(workerId, channel);
 
     eventStream.write({
         requestId: requestId,

--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -3,68 +3,23 @@
 
 import { Context } from '@azure/functions';
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
-import { functionEnvironmentReloadRequest } from './eventHandlers/functionEnvironmentReloadRequest';
-import { functionLoadRequest } from './eventHandlers/functionLoadRequest';
-import { invocationRequest } from './eventHandlers/invocationRequest';
-import { workerInitRequest } from './eventHandlers/workerInitRequest';
-import { workerStatusRequest } from './eventHandlers/workerStatusRequest';
 import { IFunctionLoader } from './FunctionLoader';
 import { IEventStream } from './GrpcClient';
-import { InternalException } from './utils/InternalException';
-import { systemError } from './utils/Logger';
-import LogCategory = rpc.RpcLog.RpcLogCategory;
-import LogLevel = rpc.RpcLog.Level;
 
 type InvocationRequestBefore = (context: Context, userFn: Function) => Function;
 type InvocationRequestAfter = (context: Context) => void;
 
-/**
- * Initializes handlers for incoming gRPC messages on the client
- *
- * The worker channel should have a way to handle all incoming gRPC messages.
- * This includes all incoming StreamingMessage types (exclude *Response types and RpcLog type)
- */
 export class WorkerChannel {
     public eventStream: IEventStream;
     public functionLoader: IFunctionLoader;
     private _invocationRequestBefore: InvocationRequestBefore[];
     private _invocationRequestAfter: InvocationRequestAfter[];
 
-    constructor(workerId: string, eventStream: IEventStream, functionLoader: IFunctionLoader) {
+    constructor(eventStream: IEventStream, functionLoader: IFunctionLoader) {
         this.eventStream = eventStream;
         this.functionLoader = functionLoader;
         this._invocationRequestBefore = [];
         this._invocationRequestAfter = [];
-
-        // call the method with the matching 'event' name on this class, passing the requestId and event message
-        eventStream.on('data', (msg) => {
-            const event = <string>msg.content;
-            const eventHandler = (<any>this)[event];
-            if (eventHandler) {
-                eventHandler.apply(this, [msg.requestId, msg[event]]);
-            } else {
-                this.log({
-                    message: `Worker ${workerId} had no handler for message '${event}'`,
-                    level: LogLevel.Error,
-                    logCategory: LogCategory.System,
-                });
-            }
-        });
-        eventStream.on('error', function (err) {
-            systemError(`Worker ${workerId} encountered event stream error: `, err);
-            throw new InternalException(err);
-        });
-
-        // wrap event stream write to validate message correctness
-        const oldWrite = eventStream.write;
-        eventStream.write = function checkWrite(msg) {
-            const msgError = rpc.StreamingMessage.verify(msg);
-            if (msgError) {
-                systemError(`Worker ${workerId} malformed message`, msgError);
-                throw new InternalException(msgError);
-            }
-            oldWrite.apply(eventStream, [msg]);
-        };
     }
 
     /**
@@ -91,83 +46,6 @@ export class WorkerChannel {
      */
     public registerAfterInvocationRequest(afterCb: InvocationRequestAfter): void {
         this._invocationRequestAfter.push(afterCb);
-    }
-
-    /**
-     * Host sends capabilities/init data to worker and requests the worker to initialize itself
-     * @param requestId gRPC message request id
-     * @param msg gRPC message content
-     */
-    public workerInitRequest(requestId: string, _msg: rpc.WorkerInitRequest) {
-        workerInitRequest(this, requestId, _msg);
-    }
-
-    /**
-     * Worker responds after loading required metadata to load function with the load result
-     * @param requestId gRPC message request id
-     * @param msg gRPC message content
-     */
-    public async functionLoadRequest(requestId: string, msg: rpc.FunctionLoadRequest) {
-        await functionLoadRequest(this, requestId, msg);
-    }
-
-    /**
-     * Host requests worker to invoke a Function
-     * @param requestId gRPC message request id
-     * @param msg gRPC message content
-     */
-    public invocationRequest(requestId: string, msg: rpc.InvocationRequest) {
-        invocationRequest(this, requestId, msg);
-    }
-
-    /**
-     * Worker sends the host information identifying itself
-     */
-    public startStream(_requestId: string, _msg: rpc.StartStream): void {
-        // Not yet implemented
-    }
-
-    /**
-     * Message is empty by design - Will add more fields in future if needed
-     */
-    public workerHeartbeat(_requestId: string, _msg: rpc.WorkerHeartbeat): void {
-        // Not yet implemented
-    }
-
-    /**
-     * Warning before killing the process after grace_period
-     * Worker self terminates ..no response on this
-     */
-    public workerTerminate(_requestId: string, _msg: rpc.WorkerTerminate): void {
-        // Not yet implemented
-    }
-
-    /**
-     * Worker sends the host empty response to evaluate the worker's latency
-     */
-    public workerStatusRequest(requestId: string, _msg: rpc.WorkerStatusRequest): void {
-        workerStatusRequest(this, requestId, _msg);
-    }
-
-    /**
-     * Host notifies worker of file content change
-     */
-    public fileChangeEventRequest(_requestId: string, _msg: rpc.FileChangeEventRequest): void {
-        // Not yet implemented
-    }
-
-    /**
-     * Host requests worker to cancel invocation
-     */
-    public invocationCancel(_requestId: string, _msg: rpc.InvocationCancel): void {
-        // Not yet implemented
-    }
-
-    /**
-     * Environment variables from the current process
-     */
-    public functionEnvironmentReloadRequest(requestId: string, msg: rpc.IFunctionEnvironmentReloadRequest): void {
-        functionEnvironmentReloadRequest(this, requestId, msg);
     }
 
     public runInvocationRequestBefore(context: Context, userFunction: Function): Function {

--- a/src/eventHandlers/functionLoadRequest.ts
+++ b/src/eventHandlers/functionLoadRequest.ts
@@ -13,7 +13,7 @@ import LogLevel = rpc.RpcLog.Level;
  * @param requestId gRPC message request id
  * @param msg gRPC message content
  */
-export async function functionLoadRequest(channel: WorkerChannel, requestId: string, msg: rpc.FunctionLoadRequest) {
+export async function functionLoadRequest(channel: WorkerChannel, requestId: string, msg: rpc.IFunctionLoadRequest) {
     if (msg.functionId && msg.metadata) {
         let error: Error | null | undefined;
         let errorMessage: string | undefined;

--- a/src/eventHandlers/invocationRequest.ts
+++ b/src/eventHandlers/invocationRequest.ts
@@ -5,6 +5,7 @@ import { format } from 'util';
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
 import { CreateContextAndInputs, LogCallback, ResultCallback } from '../Context';
 import { toTypedData } from '../converters';
+import { nonNullProp } from '../utils/nonNull';
 import { toRpcStatus } from '../utils/toRpcStatus';
 import { WorkerChannel } from '../WorkerChannel';
 import LogCategory = rpc.RpcLog.RpcLogCategory;
@@ -15,8 +16,8 @@ import LogLevel = rpc.RpcLog.Level;
  * @param requestId gRPC message request id
  * @param msg gRPC message content
  */
-export function invocationRequest(channel: WorkerChannel, requestId: string, msg: rpc.InvocationRequest) {
-    const info = channel.functionLoader.getInfo(msg.functionId);
+export function invocationRequest(channel: WorkerChannel, requestId: string, msg: rpc.IInvocationRequest) {
+    const info = channel.functionLoader.getInfo(nonNullProp(msg, 'functionId'));
     const logCallback: LogCallback = (level, category, ...args) => {
         channel.log({
             invocationId: msg.invocationId,
@@ -106,7 +107,7 @@ export function invocationRequest(channel: WorkerChannel, requestId: string, msg
     };
 
     const { context, inputs } = CreateContextAndInputs(info, msg, logCallback, resultCallback);
-    let userFunction = channel.functionLoader.getFunc(msg.functionId);
+    let userFunction = channel.functionLoader.getFunc(nonNullProp(msg, 'functionId'));
 
     userFunction = channel.runInvocationRequestBefore(context, userFunction);
 

--- a/src/eventHandlers/workerInitRequest.ts
+++ b/src/eventHandlers/workerInitRequest.ts
@@ -17,7 +17,7 @@ import LogLevel = rpc.RpcLog.Level;
  * @param requestId gRPC message request id
  * @param msg gRPC message content
  */
-export function workerInitRequest(channel: WorkerChannel, requestId: string, _msg: rpc.WorkerInitRequest) {
+export function workerInitRequest(channel: WorkerChannel, requestId: string, _msg: rpc.IWorkerInitRequest) {
     // Validate version
     const version = process.version;
     if (

--- a/src/eventHandlers/workerStatusRequest.ts
+++ b/src/eventHandlers/workerStatusRequest.ts
@@ -7,7 +7,7 @@ import { WorkerChannel } from '../WorkerChannel';
 /**
  * Worker sends the host empty response to evaluate the worker's latency
  */
-export function workerStatusRequest(channel: WorkerChannel, requestId: string, _msg: rpc.WorkerStatusRequest): void {
+export function workerStatusRequest(channel: WorkerChannel, requestId: string, _msg: rpc.IWorkerStatusRequest): void {
     const workerStatusResponse: rpc.IWorkerStatusResponse = {};
     channel.eventStream.write({
         requestId: requestId,

--- a/src/setupEventStream.ts
+++ b/src/setupEventStream.ts
@@ -1,0 +1,86 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
+import { functionEnvironmentReloadRequest } from './eventHandlers/functionEnvironmentReloadRequest';
+import { functionLoadRequest } from './eventHandlers/functionLoadRequest';
+import { invocationRequest } from './eventHandlers/invocationRequest';
+import { workerInitRequest } from './eventHandlers/workerInitRequest';
+import { workerStatusRequest } from './eventHandlers/workerStatusRequest';
+import { IFunctionLoader } from './FunctionLoader';
+import { IEventStream } from './GrpcClient';
+import { InternalException } from './utils/InternalException';
+import { systemError } from './utils/Logger';
+import { nonNullProp } from './utils/nonNull';
+import { WorkerChannel } from './WorkerChannel';
+import LogCategory = rpc.RpcLog.RpcLogCategory;
+import LogLevel = rpc.RpcLog.Level;
+
+/**
+ * Configures handlers for incoming gRPC messages on the client
+ *
+ * This should have a way to handle all incoming gRPC messages.
+ * This includes all incoming StreamingMessage types (exclude *Response types and RpcLog type)
+ */
+export function setupEventStream(
+    workerId: string,
+    eventStream: IEventStream,
+    functionLoader: IFunctionLoader
+): WorkerChannel {
+    const channel = new WorkerChannel(eventStream, functionLoader);
+
+    eventStream.on('data', (msg) => {
+        const eventName = msg.content;
+        switch (eventName) {
+            case 'functionEnvironmentReloadRequest':
+                functionEnvironmentReloadRequest(channel, msg.requestId, nonNullProp(msg, eventName));
+                break;
+            case 'functionLoadRequest':
+                void functionLoadRequest(channel, msg.requestId, nonNullProp(msg, eventName));
+                break;
+            case 'invocationRequest':
+                invocationRequest(channel, msg.requestId, nonNullProp(msg, eventName));
+                break;
+            case 'workerInitRequest':
+                workerInitRequest(channel, msg.requestId, nonNullProp(msg, eventName));
+                break;
+            case 'workerStatusRequest':
+                workerStatusRequest(channel, msg.requestId, nonNullProp(msg, eventName));
+                break;
+            case 'closeSharedMemoryResourcesRequest':
+            case 'fileChangeEventRequest':
+            case 'functionLoadRequestCollection':
+            case 'functionsMetadataRequest':
+            case 'invocationCancel':
+            case 'startStream':
+            case 'workerHeartbeat':
+            case 'workerTerminate':
+                // Not yet implemented
+                break;
+            default:
+                channel.log({
+                    message: `Worker ${workerId} had no handler for message '${eventName}'`,
+                    level: LogLevel.Error,
+                    logCategory: LogCategory.System,
+                });
+        }
+    });
+
+    eventStream.on('error', function (err) {
+        systemError(`Worker ${workerId} encountered event stream error: `, err);
+        throw new InternalException(err);
+    });
+
+    // wrap event stream write to validate message correctness
+    const oldWrite = eventStream.write;
+    eventStream.write = function checkWrite(msg) {
+        const msgError = rpc.StreamingMessage.verify(msg);
+        if (msgError) {
+            systemError(`Worker ${workerId} malformed message`, msgError);
+            throw new InternalException(msgError);
+        }
+        oldWrite.apply(eventStream, [msg]);
+    };
+
+    return channel;
+}

--- a/src/utils/nonNull.ts
+++ b/src/utils/nonNull.ts
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+/**
+ * Retrieves a property by name from an object and checks that it's not null and not undefined.  It is strongly typed
+ * for the property and will give a compile error if the given name is not a property of the source.
+ */
+export function nonNullProp<TSource, TKey extends keyof TSource>(
+    source: TSource,
+    name: TKey
+): NonNullable<TSource[TKey]> {
+    const value: NonNullable<TSource[TKey]> = <NonNullable<TSource[TKey]>>source[name];
+    return nonNullValue(value, <string>name);
+}
+
+/**
+ * Validates that a given value is not null and not undefined.
+ */
+export function nonNullValue<T>(value: T | undefined, propertyNameOrMessage?: string): T {
+    if (value === null || value === undefined) {
+        throw new Error(
+            'Internal error: Expected value to be neither null nor undefined' +
+                (propertyNameOrMessage ? `: ${propertyNameOrMessage}` : '')
+        );
+    }
+
+    return value;
+}

--- a/test/eventHandlers/beforeEventHandlerSuite.ts
+++ b/test/eventHandlers/beforeEventHandlerSuite.ts
@@ -4,11 +4,13 @@
 import * as sinon from 'sinon';
 import { FunctionLoader } from '../../src/FunctionLoader';
 import { setupEventStream } from '../../src/setupEventStream';
+import { WorkerChannel } from '../../src/WorkerChannel';
 import { TestEventStream } from './TestEventStream';
 
 export function beforeEventHandlerSuite() {
     const stream = new TestEventStream();
     const loader = sinon.createStubInstance<FunctionLoader>(FunctionLoader);
-    const channel = setupEventStream('workerId', stream, loader);
+    const channel = new WorkerChannel(stream, loader);
+    setupEventStream('workerId', channel);
     return { stream, loader, channel };
 }

--- a/test/eventHandlers/beforeEventHandlerSuite.ts
+++ b/test/eventHandlers/beforeEventHandlerSuite.ts
@@ -3,12 +3,12 @@
 
 import * as sinon from 'sinon';
 import { FunctionLoader } from '../../src/FunctionLoader';
-import { WorkerChannel } from '../../src/WorkerChannel';
+import { setupEventStream } from '../../src/setupEventStream';
 import { TestEventStream } from './TestEventStream';
 
 export function beforeEventHandlerSuite() {
     const stream = new TestEventStream();
     const loader = sinon.createStubInstance<FunctionLoader>(FunctionLoader);
-    const channel = new WorkerChannel('workerId', stream, loader);
+    const channel = setupEventStream('workerId', stream, loader);
     return { stream, loader, channel };
 }


### PR DESCRIPTION
This is a continuation of https://github.com/Azure/azure-functions-nodejs-worker/pull/543 where I try to slim down `WorkerChannel`. The main problems addressed by this PR:
1. The constructor of `WorkerChannel` has side effects, which is confusing and an anti-pattern in Node.js (as discussed [here](https://github.com/Azure/azure-functions-nodejs-worker/pull/535#discussion_r807195686))
2. The `eventStream.on('data'` logic felt too "auto-magic" to me, which made it confusing. My new data handler is intended to be more straightforward and it has better type safety (aka no more stuff like `<string>`, `<any>`, `.apply()`) 