### PR TITLE
Refactor source code to use async/await instead of done

### DIFF
--- a/src/Context.ts
+++ b/src/Context.ts
@@ -22,16 +22,12 @@ import {
 import { FunctionInfo } from './FunctionInfo';
 import { Request } from './http/Request';
 import { Response } from './http/Response';
+import EventEmitter = require('events');
 import LogLevel = rpc.RpcLog.Level;
-import LogCategory = rpc.RpcLog.RpcLogCategory;
 
-export function CreateContextAndInputs(
-    info: FunctionInfo,
-    request: rpc.IInvocationRequest,
-    logCallback: LogCallback,
-    callback: ResultCallback
-) {
-    const context = new InvocationContext(info, request, logCallback, callback);
+export function CreateContextAndInputs(info: FunctionInfo, request: rpc.IInvocationRequest, logCallback: LogCallback) {
+    const doneEmitter = new EventEmitter();
+    const context = new InvocationContext(info, request, logCallback, doneEmitter);
 
     const bindings: ContextBindings = {};
     const inputs: any[] = [];
@@ -76,6 +72,7 @@ export function CreateContextAndInputs(
     return {
         context: <Context>context,
         inputs: inputs,
+        doneEmitter,
     };
 }
 
@@ -95,7 +92,7 @@ class InvocationContext implements Context {
         info: FunctionInfo,
         request: rpc.IInvocationRequest,
         logCallback: LogCallback,
-        callback: ResultCallback
+        doneEmitter: EventEmitter
     ) {
         this.invocationId = <string>request.invocationId;
         this.traceContext = fromRpcTraceContext(request.traceContext);
@@ -107,77 +104,22 @@ class InvocationContext implements Context {
         };
         this.executionContext = executionContext;
         this.bindings = {};
-        let _done = false;
-        let _promise = false;
 
         // Log message that is tied to function invocation
-        this.log = Object.assign(
-            (...args: any[]) => logWithAsyncCheck(_done, logCallback, LogLevel.Information, executionContext, ...args),
-            {
-                error: (...args: any[]) =>
-                    logWithAsyncCheck(_done, logCallback, LogLevel.Error, executionContext, ...args),
-                warn: (...args: any[]) =>
-                    logWithAsyncCheck(_done, logCallback, LogLevel.Warning, executionContext, ...args),
-                info: (...args: any[]) =>
-                    logWithAsyncCheck(_done, logCallback, LogLevel.Information, executionContext, ...args),
-                verbose: (...args: any[]) =>
-                    logWithAsyncCheck(_done, logCallback, LogLevel.Trace, executionContext, ...args),
-            }
-        );
+        this.log = Object.assign((...args: any[]) => logCallback(LogLevel.Information, ...args), {
+            error: (...args: any[]) => logCallback(LogLevel.Error, ...args),
+            warn: (...args: any[]) => logCallback(LogLevel.Warning, ...args),
+            info: (...args: any[]) => logCallback(LogLevel.Information, ...args),
+            verbose: (...args: any[]) => logCallback(LogLevel.Trace, ...args),
+        });
 
         this.bindingData = getNormalizedBindingData(request);
         this.bindingDefinitions = getBindingDefinitions(info);
 
-        // isPromise is a hidden parameter that we set to true in the event of a returned promise
-        this.done = (err?: any, result?: any, isPromise?: boolean) => {
-            _promise = isPromise === true;
-            if (_done) {
-                if (_promise) {
-                    logCallback(
-                        LogLevel.Error,
-                        LogCategory.User,
-                        "Error: Choose either to return a promise or call 'done'.  Do not use both in your script."
-                    );
-                } else {
-                    logCallback(
-                        LogLevel.Error,
-                        LogCategory.User,
-                        "Error: 'done' has already been called. Please check your script for extraneous calls to 'done'."
-                    );
-                }
-                return;
-            }
-            _done = true;
-
-            // Allow HTTP response from context.res if HTTP response is not defined from the context.bindings object
-            if (info.httpOutputName && this.res && this.bindings[info.httpOutputName] === undefined) {
-                this.bindings[info.httpOutputName] = this.res;
-            }
-
-            callback(err, {
-                return: result,
-                bindings: this.bindings,
-            });
+        this.done = (err?: unknown, result?: any) => {
+            doneEmitter.emit('done', err, result);
         };
     }
-}
-
-// Emit warning if trying to log after function execution is done.
-function logWithAsyncCheck(
-    done: boolean,
-    log: LogCallback,
-    level: LogLevel,
-    executionContext: ExecutionContext,
-    ...args: any[]
-) {
-    if (done) {
-        let badAsyncMsg =
-            "Warning: Unexpected call to 'log' on the context object after function execution has completed. Please check for asynchronous calls that are not awaited or calls to 'done' made before function execution completes. ";
-        badAsyncMsg += `Function name: ${executionContext.functionName}. Invocation Id: ${executionContext.invocationId}. `;
-        badAsyncMsg += `Learn more: https://go.microsoft.com/fwlink/?linkid=2097909 `;
-        log(LogLevel.Warning, LogCategory.System, badAsyncMsg);
-    }
-    return log(level, LogCategory.User, ...args);
 }
 
 export interface InvocationResult {
@@ -185,11 +127,9 @@ export interface InvocationResult {
     bindings: ContextBindings;
 }
 
-export type DoneCallback = (err?: Error | string, result?: any) => void;
+export type DoneCallback = (err?: unknown, result?: any) => void;
 
-export type LogCallback = (level: LogLevel, category: rpc.RpcLog.RpcLogCategory, ...args: any[]) => void;
-
-export type ResultCallback = (err?: any, result?: InvocationResult) => void;
+export type LogCallback = (level: LogLevel, ...args: any[]) => void;
 
 export interface Dict<T> {
     [key: string]: T;

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -25,9 +25,13 @@ import { Response } from './http/Response';
 import EventEmitter = require('events');
 import LogLevel = rpc.RpcLog.Level;
 
-export function CreateContextAndInputs(info: FunctionInfo, request: rpc.IInvocationRequest, logCallback: LogCallback) {
+export function CreateContextAndInputs(
+    info: FunctionInfo,
+    request: rpc.IInvocationRequest,
+    userLogCallback: UserLogCallback
+) {
     const doneEmitter = new EventEmitter();
-    const context = new InvocationContext(info, request, logCallback, doneEmitter);
+    const context = new InvocationContext(info, request, userLogCallback, doneEmitter);
 
     const bindings: ContextBindings = {};
     const inputs: any[] = [];
@@ -91,7 +95,7 @@ class InvocationContext implements Context {
     constructor(
         info: FunctionInfo,
         request: rpc.IInvocationRequest,
-        logCallback: LogCallback,
+        userLogCallback: UserLogCallback,
         doneEmitter: EventEmitter
     ) {
         this.invocationId = <string>request.invocationId;
@@ -106,11 +110,11 @@ class InvocationContext implements Context {
         this.bindings = {};
 
         // Log message that is tied to function invocation
-        this.log = Object.assign((...args: any[]) => logCallback(LogLevel.Information, ...args), {
-            error: (...args: any[]) => logCallback(LogLevel.Error, ...args),
-            warn: (...args: any[]) => logCallback(LogLevel.Warning, ...args),
-            info: (...args: any[]) => logCallback(LogLevel.Information, ...args),
-            verbose: (...args: any[]) => logCallback(LogLevel.Trace, ...args),
+        this.log = Object.assign((...args: any[]) => userLogCallback(LogLevel.Information, ...args), {
+            error: (...args: any[]) => userLogCallback(LogLevel.Error, ...args),
+            warn: (...args: any[]) => userLogCallback(LogLevel.Warning, ...args),
+            info: (...args: any[]) => userLogCallback(LogLevel.Information, ...args),
+            verbose: (...args: any[]) => userLogCallback(LogLevel.Trace, ...args),
         });
 
         this.bindingData = getNormalizedBindingData(request);
@@ -129,7 +133,7 @@ export interface InvocationResult {
 
 export type DoneCallback = (err?: unknown, result?: any) => void;
 
-export type LogCallback = (level: LogLevel, ...args: any[]) => void;
+export type UserLogCallback = (level: LogLevel, ...args: any[]) => void;
 
 export interface Dict<T> {
     [key: string]: T;

--- a/src/eventHandlers/invocationRequest.ts
+++ b/src/eventHandlers/invocationRequest.ts
@@ -43,6 +43,9 @@ export async function invocationRequest(channel: WorkerChannel, requestId: strin
         log(level, LogCategory.System, ...args);
     }
     function userLog(level: LogLevel, ...args: any[]) {
+        log(level, LogCategory.User, ...args);
+    }
+    function contextUserLog(level: LogLevel, ...args: any[]) {
         if (isDone) {
             let badAsyncMsg =
                 "Warning: Unexpected call to 'log' on the context object after function execution has completed. Please check for asynchronous calls that are not awaited or calls to 'done' made before function execution completes. ";
@@ -50,7 +53,7 @@ export async function invocationRequest(channel: WorkerChannel, requestId: strin
             badAsyncMsg += `Learn more: https://go.microsoft.com/fwlink/?linkid=2097909 `;
             systemLog(LogLevel.Warning, badAsyncMsg);
         }
-        log(level, LogCategory.User, ...args);
+        userLog(level, ...args);
     }
 
     // Log invocation details to ensure the invocation received by node worker
@@ -61,12 +64,12 @@ export async function invocationRequest(channel: WorkerChannel, requestId: strin
             const message = resultIsPromise
                 ? "Error: Choose either to return a promise or call 'done'.  Do not use both in your script."
                 : "Error: 'done' has already been called. Please check your script for extraneous calls to 'done'.";
-            systemLog(LogLevel.Error, message);
+            userLog(LogLevel.Error, message);
         }
         isDone = true;
     }
 
-    const { context, inputs, doneEmitter } = CreateContextAndInputs(info, msg, userLog);
+    const { context, inputs, doneEmitter } = CreateContextAndInputs(info, msg, contextUserLog);
     try {
         const legacyDoneTask = new Promise((resolve, reject) => {
             doneEmitter.on('done', (err?: unknown, result?: any) => {

--- a/src/setupEventStream.ts
+++ b/src/setupEventStream.ts
@@ -31,7 +31,7 @@ export function setupEventStream(workerId: string, channel: WorkerChannel): void
                 void functionLoadRequest(channel, msg.requestId, nonNullProp(msg, eventName));
                 break;
             case 'invocationRequest':
-                invocationRequest(channel, msg.requestId, nonNullProp(msg, eventName));
+                void invocationRequest(channel, msg.requestId, nonNullProp(msg, eventName));
                 break;
             case 'workerInitRequest':
                 workerInitRequest(channel, msg.requestId, nonNullProp(msg, eventName));

--- a/test/ContextTests.ts
+++ b/test/ContextTests.ts
@@ -25,11 +25,9 @@ const timerTriggerInput: rpc.IParameterBinding = {
 
 describe('Context', () => {
     let _logger: any;
-    let _resultCallback: any;
 
     beforeEach(() => {
         _logger = sinon.spy();
-        _resultCallback = sinon.spy();
     });
 
     it('camelCases timer trigger input when appropriate', async () => {
@@ -49,7 +47,7 @@ describe('Context', () => {
                 },
             },
         });
-        const workerOutputs = CreateContextAndInputs(info, msg, _logger, _resultCallback);
+        const workerOutputs = CreateContextAndInputs(info, msg, _logger);
         const myTimerWorker = workerOutputs.inputs[0];
         expect(myTimerWorker.schedule).to.be.empty;
         expect(myTimerWorker.scheduleStatus.last).to.equal('2016-10-04T10:15:00+00:00');
@@ -76,7 +74,7 @@ describe('Context', () => {
             },
         });
 
-        const { context } = CreateContextAndInputs(info, msg, _logger, _resultCallback);
+        const { context } = CreateContextAndInputs(info, msg, _logger);
         expect(context.bindingData.sys).to.be.undefined;
         expect(context.bindingData.invocationId).to.equal('1');
         expect(context.invocationId).to.equal('1');
@@ -110,7 +108,7 @@ describe('Context', () => {
             },
         });
 
-        const { context } = CreateContextAndInputs(info, msg, _logger, _resultCallback);
+        const { context } = CreateContextAndInputs(info, msg, _logger);
         const { bindingData } = context;
         expect(bindingData.sys.methodName).to.equal('test');
         expect(bindingData.sys.randGuid).to.not.be.undefined;
@@ -163,7 +161,7 @@ describe('Context', () => {
             },
         });
 
-        const { context } = CreateContextAndInputs(info, msg, _logger, _resultCallback);
+        const { context } = CreateContextAndInputs(info, msg, _logger);
         const { bindingData } = context;
         expect(bindingData.invocationId).to.equal('1');
         expect(bindingData.headers.header1).to.equal('value1');
@@ -207,7 +205,7 @@ describe('Context', () => {
             },
         });
 
-        const { context } = CreateContextAndInputs(info, msg, _logger, _resultCallback);
+        const { context } = CreateContextAndInputs(info, msg, _logger);
         const { bindingData } = context;
         expect(bindingData.invocationId).to.equal('1');
         expect(bindingData.headers.header1).to.equal('value1');

--- a/test/eventHandlers/invocationRequest.test.ts
+++ b/test/eventHandlers/invocationRequest.test.ts
@@ -169,7 +169,7 @@ namespace Msg {
             invocationId: '1',
             message: "Error: Choose either to return a promise or call 'done'.  Do not use both in your script.",
             level: LogLevel.Error,
-            logCategory: LogCategory.User,
+            logCategory: LogCategory.System,
         },
     };
     export const duplicateDoneLog: rpc.IStreamingMessage = {
@@ -178,7 +178,7 @@ namespace Msg {
             invocationId: '1',
             message: "Error: 'done' has already been called. Please check your script for extraneous calls to 'done'.",
             level: LogLevel.Error,
-            logCategory: LogCategory.User,
+            logCategory: LogCategory.System,
         },
     };
     export const unexpectedLogAfterDoneLog: rpc.IStreamingMessage = {
@@ -438,8 +438,8 @@ describe('invocationRequest', () => {
         sendInvokeMessage([httpInputData]);
         await stream.assertCalledWith(
             Msg.receivedInvocLog(),
-            Msg.invocResponse([getHttpResponse()]),
-            Msg.asyncAndDoneLog
+            Msg.asyncAndDoneLog,
+            Msg.invocResponse([getHttpResponse()])
         );
     });
 
@@ -452,8 +452,8 @@ describe('invocationRequest', () => {
         sendInvokeMessage([httpInputData]);
         await stream.assertCalledWith(
             Msg.receivedInvocLog(),
-            Msg.invocResponse([getHttpResponse()]),
-            Msg.duplicateDoneLog
+            Msg.duplicateDoneLog,
+            Msg.invocResponse([getHttpResponse()])
         );
     });
 
@@ -466,9 +466,9 @@ describe('invocationRequest', () => {
         sendInvokeMessage([httpInputData]);
         await stream.assertCalledWith(
             Msg.receivedInvocLog(),
-            Msg.invocResponse([getHttpResponse()]),
             Msg.unexpectedLogAfterDoneLog,
-            Msg.userTestLog
+            Msg.userTestLog,
+            Msg.invocResponse([getHttpResponse()])
         );
     });
 

--- a/test/eventHandlers/invocationRequest.test.ts
+++ b/test/eventHandlers/invocationRequest.test.ts
@@ -169,7 +169,7 @@ namespace Msg {
             invocationId: '1',
             message: "Error: Choose either to return a promise or call 'done'.  Do not use both in your script.",
             level: LogLevel.Error,
-            logCategory: LogCategory.System,
+            logCategory: LogCategory.User,
         },
     };
     export const duplicateDoneLog: rpc.IStreamingMessage = {
@@ -178,7 +178,7 @@ namespace Msg {
             invocationId: '1',
             message: "Error: 'done' has already been called. Please check your script for extraneous calls to 'done'.",
             level: LogLevel.Error,
-            logCategory: LogCategory.System,
+            logCategory: LogCategory.User,
         },
     };
     export const unexpectedLogAfterDoneLog: rpc.IStreamingMessage = {


### PR DESCRIPTION
This is the second piece of https://github.com/Azure/azure-functions-nodejs-worker/pull/545, but focused on source code instead of test code. If we're going to encourage users to use "async/await" over "context.done", our own code should default to async/await behavior as well. I removed all logic from "context.done" and it's now a simple event emitter whose sole purpose is to maintain backwards compatibility.

There's very minor changes to the logs (as evidenced by my changes to the test files), but otherwise functionality should be the exact same.