### PR TITLE
Add deprecation flag for context.done()

### DIFF
--- a/test/FunctionLoaderTests.ts
+++ b/test/FunctionLoaderTests.ts
@@ -82,6 +82,7 @@ describe('FunctionLoader', () => {
             }
             FuncObject.prototype.index = function (ctx) {
                 ctx.bindings.prop = this.test();
+                // eslint-disable-next-line deprecation/deprecation
                 ctx.done();
             };
             FuncObject.prototype.test = function () {

--- a/test/eventHandlers/invocationRequest.test.ts
+++ b/test/eventHandlers/invocationRequest.test.ts
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
+/* eslint-disable deprecation/deprecation */
+
 import { AzureFunction, Context } from '@azure/functions';
 import { expect } from 'chai';
 import 'mocha';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -76,6 +76,9 @@ declare module '@azure/functions' {
          * @param err A user-defined error to pass back to the runtime. If present, your function execution will fail.
          * @param result An object containing output binding data. `result` will be passed to JSON.stringify unless it is
          *  a string, Buffer, ArrayBufferView, or number.
+         *
+         * @deprecated Use of sync functions with `context.done()` is deprecated. Use async/await and pass the response as the return value instead.
+         * See the docs here for more information: https://aka.ms/functions-js-async-await
          */
         done(err?: Error | string | null, result?: any): void;
         /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -77,7 +77,7 @@ declare module '@azure/functions' {
          * @param result An object containing output binding data. `result` will be passed to JSON.stringify unless it is
          *  a string, Buffer, ArrayBufferView, or number.
          *
-         * @deprecated Use of sync functions with `context.done()` is deprecated. Use async/await and pass the response as the return value instead.
+         * @deprecated Use of sync functions with `context.done()` is not recommended. Use async/await and pass the response as the return value instead.
          * See the docs here for more information: https://aka.ms/functions-js-async-await
          */
         done(err?: Error | string | null, result?: any): void;


### PR DESCRIPTION
Adds a `@deprecated` flag for `context.done()`, and adds comments to remove deprecation linting errors.

Question: is this considered a breaking change? If a customer was also using the deprecation linting flag, this would break previously working code. 