### PR TITLE
Switch context.res type to HttpResponse

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -85,9 +85,7 @@ declare module '@azure/functions' {
         /**
          * HTTP response object. Provided to your function when using HTTP Bindings.
          */
-        res?: {
-            [key: string]: any;
-        };
+        res?: HttpResponse;
     }
     /**
      * HTTP request headers.


### PR DESCRIPTION
Change the default type of `context.res` from `{ [key: string]: any }` (very generic and not very helpful) to leverage the new `HttpRespone` types introduced in #529. This is a breaking change, so was left to a separate PR. See the discussion there for why this is a breaking change and the different workarounds. Moving discussion here on when/how/if we want to make this change.