### PR TITLE
Bump .NET version for E2E tests on v2.x branch

### DIFF
--- a/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E.csproj
+++ b/test/end-to-end/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E/Azure.Functions.NodejsWorker.E2E.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Build agents don't have .NET 2.1 anymore (not surprising), so tests are currently failing.

cc @Francisco-Gamino this should fix the Node integration test failures