### PR TITLE
Use system log category for errors after done

### DIFF
--- a/src/eventHandlers/invocationRequest.ts
+++ b/src/eventHandlers/invocationRequest.ts
@@ -29,6 +29,7 @@ export async function invocationRequest(channel: WorkerChannel, requestId: strin
     let resultIsPromise = false;
 
     const info = channel.functionLoader.getInfo(nonNullProp(msg, 'functionId'));
+    const asyncDoneLearnMoreLink = 'https://go.microsoft.com/fwlink/?linkid=2097909';
 
     function log(level: LogLevel, category: LogCategory, ...args: any[]) {
         channel.log({
@@ -47,7 +48,7 @@ export async function invocationRequest(channel: WorkerChannel, requestId: strin
             let badAsyncMsg =
                 "Warning: Unexpected call to 'log' on the context object after function execution has completed. Please check for asynchronous calls that are not awaited or calls to 'done' made before function execution completes. ";
             badAsyncMsg += `Function name: ${info.name}. Invocation Id: ${msg.invocationId}. `;
-            badAsyncMsg += `Learn more: https://go.microsoft.com/fwlink/?linkid=2097909 `;
+            badAsyncMsg += `Learn more: ${asyncDoneLearnMoreLink}`;
             systemLog(LogLevel.Warning, badAsyncMsg);
         }
         log(level, LogCategory.User, ...args);
@@ -59,7 +60,7 @@ export async function invocationRequest(channel: WorkerChannel, requestId: strin
     function onDone(): void {
         if (isDone) {
             const message = resultIsPromise
-                ? "Error: Choose either to return a promise or call 'done'.  Do not use both in your script."
+                ? `Error: Choose either to return a promise or call 'done'. Do not use both in your script. Learn more: ${asyncDoneLearnMoreLink}`
                 : "Error: 'done' has already been called. Please check your script for extraneous calls to 'done'.";
             systemLog(LogLevel.Error, message);
         }

--- a/src/eventHandlers/invocationRequest.ts
+++ b/src/eventHandlers/invocationRequest.ts
@@ -43,9 +43,6 @@ export async function invocationRequest(channel: WorkerChannel, requestId: strin
         log(level, LogCategory.System, ...args);
     }
     function userLog(level: LogLevel, ...args: any[]) {
-        log(level, LogCategory.User, ...args);
-    }
-    function contextUserLog(level: LogLevel, ...args: any[]) {
         if (isDone) {
             let badAsyncMsg =
                 "Warning: Unexpected call to 'log' on the context object after function execution has completed. Please check for asynchronous calls that are not awaited or calls to 'done' made before function execution completes. ";
@@ -53,7 +50,7 @@ export async function invocationRequest(channel: WorkerChannel, requestId: strin
             badAsyncMsg += `Learn more: https://go.microsoft.com/fwlink/?linkid=2097909 `;
             systemLog(LogLevel.Warning, badAsyncMsg);
         }
-        userLog(level, ...args);
+        log(level, LogCategory.User, ...args);
     }
 
     // Log invocation details to ensure the invocation received by node worker
@@ -64,12 +61,12 @@ export async function invocationRequest(channel: WorkerChannel, requestId: strin
             const message = resultIsPromise
                 ? "Error: Choose either to return a promise or call 'done'.  Do not use both in your script."
                 : "Error: 'done' has already been called. Please check your script for extraneous calls to 'done'.";
-            userLog(LogLevel.Error, message);
+            systemLog(LogLevel.Error, message);
         }
         isDone = true;
     }
 
-    const { context, inputs, doneEmitter } = CreateContextAndInputs(info, msg, contextUserLog);
+    const { context, inputs, doneEmitter } = CreateContextAndInputs(info, msg, userLog);
     try {
         const legacyDoneTask = new Promise((resolve, reject) => {
             doneEmitter.on('done', (err?: unknown, result?: any) => {

--- a/test/eventHandlers/invocationRequest.test.ts
+++ b/test/eventHandlers/invocationRequest.test.ts
@@ -169,7 +169,8 @@ namespace Msg {
         rpcLog: {
             category: 'testFuncName.Invocation',
             invocationId: '1',
-            message: "Error: Choose either to return a promise or call 'done'.  Do not use both in your script.",
+            message:
+                "Error: Choose either to return a promise or call 'done'. Do not use both in your script. Learn more: https://go.microsoft.com/fwlink/?linkid=2097909",
             level: LogLevel.Error,
             logCategory: LogCategory.System,
         },
@@ -188,7 +189,7 @@ namespace Msg {
             category: 'testFuncName.Invocation',
             invocationId: '1',
             message:
-                "Warning: Unexpected call to 'log' on the context object after function execution has completed. Please check for asynchronous calls that are not awaited or calls to 'done' made before function execution completes. Function name: testFuncName. Invocation Id: 1. Learn more: https://go.microsoft.com/fwlink/?linkid=2097909 ",
+                "Warning: Unexpected call to 'log' on the context object after function execution has completed. Please check for asynchronous calls that are not awaited or calls to 'done' made before function execution completes. Function name: testFuncName. Invocation Id: 1. Learn more: https://go.microsoft.com/fwlink/?linkid=2097909",
             level: LogLevel.Warning,
             logCategory: LogCategory.System,
         },

--- a/test/eventHandlers/invocationRequest.test.ts
+++ b/test/eventHandlers/invocationRequest.test.ts
@@ -171,7 +171,7 @@ namespace Msg {
             invocationId: '1',
             message: "Error: Choose either to return a promise or call 'done'.  Do not use both in your script.",
             level: LogLevel.Error,
-            logCategory: LogCategory.User,
+            logCategory: LogCategory.System,
         },
     };
     export const duplicateDoneLog: rpc.IStreamingMessage = {
@@ -180,7 +180,7 @@ namespace Msg {
             invocationId: '1',
             message: "Error: 'done' has already been called. Please check your script for extraneous calls to 'done'.",
             level: LogLevel.Error,
-            logCategory: LogCategory.User,
+            logCategory: LogCategory.System,
         },
     };
     export const unexpectedLogAfterDoneLog: rpc.IStreamingMessage = {


### PR DESCRIPTION
Currently these logs are lost because they happen after execution completes and the host ignores "orphaned" user logs. Related to discussion in https://github.com/Azure/azure-functions-host/issues/8222

> User logs - Cx have access to these logs via App Insights - are super set for Function Execution logs + Host / Extension logs - Any logs coming from Host are considered as system logs and can be logged to Kusto. User logs cannot be logged to Kusto as they are considered PII

> If the error is coming from the worker itself, I would consider it a system log, especially if it doesn't include the user's actual function logs (which is the PII part).