### PR TITLE
Add lint rule to avoid TypeScript "public"

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -45,7 +45,12 @@
         "no-empty": "off",
         "prefer-const": ["error", { "destructuring": "all" }],
         "prefer-rest-params": "off",
-        "prefer-spread": "off"
+        "prefer-spread": "off",
+        "@typescript-eslint/explicit-member-accessibility": [
+            "error", {
+                "accessibility": "no-public"
+            }
+        ]
     },
     "ignorePatterns": [
         "**/*.js",

--- a/src/FunctionInfo.ts
+++ b/src/FunctionInfo.ts
@@ -7,16 +7,16 @@ import { toRpcHttp, toTypedData } from './converters';
 const returnBindingKey = '$return';
 
 export class FunctionInfo {
-    public name: string;
-    public directory: string;
-    public bindings: {
+    name: string;
+    directory: string;
+    bindings: {
         [key: string]: rpc.IBindingInfo;
     };
-    public outputBindings: {
+    outputBindings: {
         [key: string]: rpc.IBindingInfo & { converter: (any) => rpc.ITypedData };
     };
-    public httpOutputName: string;
-    public hasHttpTrigger: boolean;
+    httpOutputName: string;
+    hasHttpTrigger: boolean;
 
     constructor(metadata: rpc.IRpcFunctionMetadata) {
         this.name = <string>metadata.name;
@@ -53,11 +53,11 @@ export class FunctionInfo {
     /**
      * Return output binding details on the special key "$return" output binding
      */
-    public getReturnBinding() {
+    getReturnBinding() {
         return this.outputBindings[returnBindingKey];
     }
 
-    public getTimerTriggerName(): string | undefined {
+    getTimerTriggerName(): string | undefined {
         for (const name in this.bindings) {
             const type = this.bindings[name].type;
             if (type && type.toLowerCase() === 'timertrigger') {

--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -17,9 +17,9 @@ export interface PackageJson {
 }
 
 export class WorkerChannel {
-    public eventStream: IEventStream;
-    public functionLoader: IFunctionLoader;
-    public packageJson: PackageJson;
+    eventStream: IEventStream;
+    functionLoader: IFunctionLoader;
+    packageJson: PackageJson;
     #preInvocationHooks: HookCallback[] = [];
     #postInvocationHooks: HookCallback[] = [];
 
@@ -34,13 +34,13 @@ export class WorkerChannel {
      * @param requestId gRPC message request id
      * @param msg gRPC message content
      */
-    public log(log: rpc.IRpcLog) {
+    log(log: rpc.IRpcLog) {
         this.eventStream.write({
             rpcLog: log,
         });
     }
 
-    public registerHook(hookName: string, callback: HookCallback): Disposable {
+    registerHook(hookName: string, callback: HookCallback): Disposable {
         const hooks = this.#getHooks(hookName);
         hooks.push(callback);
         return new Disposable(() => {
@@ -51,7 +51,7 @@ export class WorkerChannel {
         });
     }
 
-    public async executeHooks(hookName: string, context: HookContext): Promise<void> {
+    async executeHooks(hookName: string, context: HookContext): Promise<void> {
         const callbacks = this.#getHooks(hookName);
         for (const callback of callbacks) {
             await callback(context);
@@ -69,7 +69,7 @@ export class WorkerChannel {
         }
     }
 
-    public async updatePackageJson(dir: string): Promise<void> {
+    async updatePackageJson(dir: string): Promise<void> {
         try {
             this.packageJson = await readJson(path.join(dir, 'package.json'));
         } catch (err) {

--- a/src/http/Request.ts
+++ b/src/http/Request.ts
@@ -18,18 +18,18 @@ import { parseForm } from '../parsers/parseForm';
 import { extractHttpUserFromHeaders } from './extractHttpUserFromHeaders';
 
 export class Request implements HttpRequest {
-    public method: HttpMethod | null;
-    public url: string;
-    public originalUrl: string;
-    public headers: HttpRequestHeaders;
-    public query: HttpRequestQuery;
-    public params: HttpRequestParams;
-    public body?: any;
-    public rawBody?: any;
+    method: HttpMethod | null;
+    url: string;
+    originalUrl: string;
+    headers: HttpRequestHeaders;
+    query: HttpRequestQuery;
+    params: HttpRequestParams;
+    body?: any;
+    rawBody?: any;
 
     #cachedUser?: HttpRequestUser | null;
 
-    public constructor(rpcHttp: rpc.IRpcHttp) {
+    constructor(rpcHttp: rpc.IRpcHttp) {
         this.method = <HttpMethod>rpcHttp.method;
         this.url = <string>rpcHttp.url;
         this.originalUrl = <string>rpcHttp.url;
@@ -40,7 +40,7 @@ export class Request implements HttpRequest {
         this.rawBody = fromRpcHttpBody(<rpc.ITypedData>rpcHttp.body);
     }
 
-    public get user(): HttpRequestUser | null {
+    get user(): HttpRequestUser | null {
         if (this.#cachedUser === undefined) {
             this.#cachedUser = extractHttpUserFromHeaders(this.headers);
         }
@@ -48,11 +48,11 @@ export class Request implements HttpRequest {
         return this.#cachedUser;
     }
 
-    public get(field: string): string | undefined {
+    get(field: string): string | undefined {
         return this.headers && this.headers[field.toLowerCase()];
     }
 
-    public parseFormBody(): Form {
+    parseFormBody(): Form {
         const contentType = this.get(HeaderName.contentType);
         if (!contentType) {
             throw new Error(`"${HeaderName.contentType}" header must be defined.`);

--- a/src/parsers/parseForm.ts
+++ b/src/parsers/parseForm.ts
@@ -38,7 +38,7 @@ export class Form implements types.Form {
         this.#parts = parts;
     }
 
-    public get(name: string): types.FormPart | null {
+    get(name: string): types.FormPart | null {
         for (const [key, value] of this.#parts) {
             if (key === name) {
                 return value;
@@ -47,7 +47,7 @@ export class Form implements types.Form {
         return null;
     }
 
-    public getAll(name: string): types.FormPart[] {
+    getAll(name: string): types.FormPart[] {
         const result: types.FormPart[] = [];
         for (const [key, value] of this.#parts) {
             if (key === name) {
@@ -57,7 +57,7 @@ export class Form implements types.Form {
         return result;
     }
 
-    public has(name: string): boolean {
+    has(name: string): boolean {
         for (const [key] of this.#parts) {
             if (key === name) {
                 return true;
@@ -70,7 +70,7 @@ export class Form implements types.Form {
         return this.#parts[Symbol.iterator]();
     }
 
-    public get length(): number {
+    get length(): number {
         return this.#parts.length;
     }
 }

--- a/src/parsers/parseHeader.ts
+++ b/src/parsers/parseHeader.ts
@@ -78,7 +78,7 @@ function parseHeaderParams(data: string): HeaderParams {
 
 export class HeaderParams {
     #params: { [name: string]: string } = {};
-    public get(name: string): string {
+    get(name: string): string {
         const result = this.#params[name.toLowerCase()];
         if (result === undefined) {
             throw new Error(`Failed to find parameter with name "${name}".`);
@@ -87,11 +87,11 @@ export class HeaderParams {
         }
     }
 
-    public has(name: string): boolean {
+    has(name: string): boolean {
         return this.#params[name.toLowerCase()] !== undefined;
     }
 
-    public add(name: string, value: string): void {
+    add(name: string, value: string): void {
         this.#params[name.toLowerCase()] = value;
     }
 }

--- a/src/utils/InternalException.ts
+++ b/src/utils/InternalException.ts
@@ -2,5 +2,5 @@
 // Licensed under the MIT License.
 
 export class InternalException extends Error {
-    public isAzureFunctionsInternalException = true;
+    isAzureFunctionsInternalException = true;
 }

--- a/test/eventHandlers/TestEventStream.ts
+++ b/test/eventHandlers/TestEventStream.ts
@@ -26,7 +26,7 @@ export class TestEventStream extends EventEmitter implements IEventStream {
     /**
      * Waits up to a second for the expected number of messages to be written and then validates those messages
      */
-    public async assertCalledWith(...expectedMsgs: rpc.IStreamingMessage[]): Promise<void> {
+    async assertCalledWith(...expectedMsgs: rpc.IStreamingMessage[]): Promise<void> {
         try {
             // Wait for up to a second for the expected number of messages to come in
             const maxTime = Date.now() + 1000;
@@ -55,7 +55,7 @@ export class TestEventStream extends EventEmitter implements IEventStream {
     /**
      * Verifies the test didn't send any extraneous messages
      */
-    public async afterEachEventHandlerTest(): Promise<void> {
+    async afterEachEventHandlerTest(): Promise<void> {
         // minor delay so that it's more likely extraneous messages are associated with this test as opposed to leaking into the next test
         await new Promise((resolve) => setTimeout(resolve, 20));
         await this.assertCalledWith();


### PR DESCRIPTION
Since we're no longer using TypeScript "private" (see https://github.com/Azure/azure-functions-nodejs-worker/pull/557), I don't think we should use TypeScript "public" either. Related to discussion in https://github.com/Azure/azure-functions-nodejs-worker/pull/485#discussion_r761349930

This eslint rule can be auto-fixed which is nice