### PR TITLE
Refactor FunctionLoader so that it returns a cloned function each time

### DIFF
--- a/test/FunctionLoader.test.ts
+++ b/test/FunctionLoader.test.ts
@@ -144,6 +144,28 @@ describe('FunctionLoader', () => {
         expect(result.then).to.be.a('function');
     });
 
+    it("function returned is a clone so that it can't affect other executions", async () => {
+        mock('test', { test: async () => {} });
+
+        await loader.load(
+            'functionId',
+            <rpc.IRpcFunctionMetadata>{
+                scriptFile: 'test',
+                entryPoint: 'test',
+            },
+            {}
+        );
+
+        const userFunction = loader.getFunc('functionId');
+        Object.assign(userFunction, { hello: 'world' });
+
+        const userFunction2 = loader.getFunc('functionId');
+
+        expect(userFunction).to.not.equal(userFunction2);
+        expect(userFunction['hello']).to.equal('world');
+        expect(userFunction2['hello']).to.be.undefined;
+    });
+
     it('respects .cjs extension', () => {
         const result = loader.isESModule('test.cjs', {
             type: 'module',


### PR DESCRIPTION
Related to https://github.com/Azure/azure-functions-nodejs-worker/issues/553, people will be able to mess with the function more easily, so I want to make sure they can't affect the function across invocations.

Interestingly, we were already cloning the function in `getEntryPoint` as a part of setting the `this` arg. I just moved the logic so that it happens during `getFunc` instead of `load` and used the slightly cleaner `bind` instead of `apply`.