### PR TITLE
Improve invocation hook logs

### DIFF
--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -51,10 +51,31 @@ export class WorkerChannel {
         });
     }
 
-    async executeHooks(hookName: string, context: HookContext): Promise<void> {
+    async executeHooks(
+        hookName: string,
+        context: HookContext,
+        invocationId?: string | null,
+        msgCategory?: string
+    ): Promise<void> {
         const callbacks = this.#getHooks(hookName);
-        for (const callback of callbacks) {
-            await callback(context);
+        if (callbacks.length > 0) {
+            this.log({
+                message: `Executing ${callbacks.length} "${hookName}" hooks`,
+                level: LogLevel.Debug,
+                logCategory: LogCategory.System,
+                invocationId,
+                category: msgCategory,
+            });
+            for (const callback of callbacks) {
+                await callback(context);
+            }
+            this.log({
+                message: `Executed "${hookName}" hooks`,
+                level: LogLevel.Debug,
+                logCategory: LogCategory.System,
+                invocationId,
+                category: msgCategory,
+            });
         }
     }
 


### PR DESCRIPTION
1. Added "Executing" and "Executed" logs around the hooks. If the hooks throw any errors, I think this will be helpful diagnosing the issue (by the user or by us in an incident)
2. Don't show the following warning if the user logs from a post execution hook
    > Warning: Unexpected call to 'log' on the context object after function execution has completed. Please check for asynchronous calls that are not awaited or calls to 'done' made before function execution completes. Function name: HttpTrigger1. Invocation Id: 4f2a98ba-bbb6-4fd3-854c-4fd9b0c28345. Learn more: https://go.microsoft.com/fwlink/?linkid=2097909