### PR TITLE
Remove unreachable/duplicate version checks

### DIFF
--- a/src/eventHandlers/WorkerInitHandler.ts
+++ b/src/eventHandlers/WorkerInitHandler.ts
@@ -7,8 +7,6 @@ import * as path from 'path';
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
 import { loadScriptFile } from '../loadScriptFile';
 import { ensureErrorType, isError } from '../utils/ensureErrorType';
-import { InternalException } from '../utils/InternalException';
-import { systemError } from '../utils/Logger';
 import { nonNullProp } from '../utils/nonNull';
 import { WorkerChannel } from '../WorkerChannel';
 import { EventHandler } from './EventHandler';
@@ -33,34 +31,6 @@ export class WorkerInitHandler extends EventHandler<'workerInitRequest', 'worker
             level: LogLevel.Debug,
             logCategory: LogCategory.System,
         });
-
-        // Validate version
-        const version = process.version;
-        if (
-            (version.startsWith('v17.') || version.startsWith('v15.')) &&
-            process.env.AZURE_FUNCTIONS_ENVIRONMENT == 'Development'
-        ) {
-            const msg =
-                'Node.js version used (' +
-                version +
-                ') is not officially supported. You may use it during local development, but must use an officially supported version on Azure:' +
-                ' https://aka.ms/functions-node-versions';
-            channel.log({
-                message: msg,
-                level: LogLevel.Warning,
-                logCategory: LogCategory.System,
-            });
-        } else if (!(version.startsWith('v14.') || version.startsWith('v16.'))) {
-            const errorMsg =
-                'Incompatible Node.js version' +
-                ' (' +
-                version +
-                ').' +
-                ' The version of the Azure Functions runtime you are using (v4) supports Node.js v14.x or Node.js v16.x' +
-                ' Refer to our documentation to see the Node.js versions supported by each version of Azure Functions: https://aka.ms/functions-node-versions';
-            systemError(errorMsg);
-            throw new InternalException(errorMsg);
-        }
 
         logColdStartWarning(channel);
         const functionAppDirectory = nonNullProp(msg, 'functionAppDirectory');

--- a/src/nodejsWorker.ts
+++ b/src/nodejsWorker.ts
@@ -3,6 +3,7 @@
 
 const logPrefix = 'LanguageWorkerConsoleLog';
 const errorPrefix = logPrefix + '[error] ';
+const warnPrefix = logPrefix + '[warn] ';
 const supportedVersions: string[] = ['v14', 'v16'];
 const devOnlyVersions: string[] = ['v15', 'v17'];
 let worker;
@@ -10,19 +11,24 @@ let worker;
 // Try validating node version
 // NOTE: This method should be manually tested if changed as it is in a sensitive code path
 //       and is JavaScript that runs on at least node version 0.10.28
-function validateNodeVersion(version) {
-    let message;
+function validateNodeVersion(version: string) {
+    let errorMessage: string | undefined;
+    let warningMessage: string | undefined;
     try {
         const versionSplit = version.split('.');
         const major = versionSplit[0];
         // process.version returns invalid output
         if (versionSplit.length != 3) {
-            message = "Could not parse Node.js version: '" + version + "'";
+            errorMessage = "Could not parse Node.js version: '" + version + "'";
             // Unsupported version note: Documentation about Node's stable versions here: https://github.com/nodejs/Release#release-plan and an explanation here: https://medium.com/swlh/understanding-how-node-releases-work-in-2018-6fd356816db4
         } else if (process.env.AZURE_FUNCTIONS_ENVIRONMENT == 'Development' && devOnlyVersions.indexOf(major) >= 0) {
-            // Allow to continue. Warning message displayed in workerInitRequest (WorkerChannel.ts)
+            warningMessage =
+                'Node.js version used (' +
+                version +
+                ') is not officially supported. You may use it during local development, but must use an officially supported version on Azure:' +
+                ' https://aka.ms/functions-node-versions';
         } else if (supportedVersions.indexOf(major) < 0) {
-            message =
+            errorMessage =
                 'Incompatible Node.js version' +
                 ' (' +
                 version +
@@ -36,9 +42,12 @@ function validateNodeVersion(version) {
         throw unknownError + err;
     }
     // Throw error for known version errors
-    if (message) {
-        console.error(errorPrefix + message);
-        throw message;
+    if (errorMessage) {
+        console.error(errorPrefix + errorMessage);
+        throw new Error(errorMessage);
+    }
+    if (warningMessage) {
+        console.warn(warnPrefix + warningMessage);
     }
 }
 


### PR DESCRIPTION
We have duplicate logic to check the Node.js version. For the case of unsupported versions, it's actually completely unreachable code in WorkerInitHandler.ts since nodejsWorker.ts is executed first and will throw an error.

Historically, I think this was only the case because v2 of the worker had more complicated logic [here](https://github.com/Azure/azure-functions-nodejs-worker/blob/v2.x/src/WorkerChannel.ts#L123) to support a v1-compat mode.

