### PR TITLE
Fix "Cannot find module" e2e test failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
                 "semver": "^7.3.5",
                 "shx": "^0.3.3",
                 "sinon": "^7.0.0",
-                "string-replace-webpack-plugin": "^0.1.3",
                 "ts-node": "^3.3.0",
                 "typescript": "^4.5.5",
                 "typescript3": "npm:typescript@~3.7.0",
@@ -1014,16 +1013,6 @@
                 "ajv": "^6.9.1"
             }
         },
-        "node_modules/amdefine": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-            "dev": true,
-            "optional": true,
-            "engines": {
-                "node": ">=0.4.2"
-            }
-        },
         "node_modules/ansi-colors": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -1119,26 +1108,11 @@
                 "node": ">=8"
             }
         },
-        "node_modules/async": {
-            "version": "0.2.10",
-            "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-            "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-            "dev": true
-        },
         "node_modules/balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
             "dev": true
-        },
-        "node_modules/big.js": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-            "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-            "dev": true,
-            "engines": {
-                "node": "*"
-            }
         },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
@@ -1407,31 +1381,6 @@
                 "node": "*"
             }
         },
-        "node_modules/css-loader": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.9.1.tgz",
-            "integrity": "sha1-LhqgDOfjDvLGp6SzAKCAp8l54Nw=",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "csso": "1.3.x",
-                "loader-utils": "~0.2.2",
-                "source-map": "~0.1.38"
-            }
-        },
-        "node_modules/csso": {
-            "version": "1.3.12",
-            "resolved": "https://registry.npmjs.org/csso/-/csso-1.3.12.tgz",
-            "integrity": "sha1-/GKGlKLTiTiqrEmWdTIY/TEc254=",
-            "dev": true,
-            "optional": true,
-            "bin": {
-                "csso": "bin/csso"
-            },
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
         "node_modules/debug": {
             "version": "4.3.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -1516,15 +1465,6 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-        },
-        "node_modules/emojis-list": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-            "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.10"
-            }
         },
         "node_modules/enhanced-resolve": {
             "version": "5.8.3",
@@ -2140,16 +2080,6 @@
                 "node": "^10.12.0 || >=12.0.0"
             }
         },
-        "node_modules/file-loader": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.8.5.tgz",
-            "integrity": "sha1-knXQMf54DyfUf19K8CvUNxPMFRs=",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "loader-utils": "~0.2.5"
-            }
-        },
         "node_modules/fill-range": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2725,15 +2655,6 @@
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
             "dev": true
         },
-        "node_modules/json5": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-            "dev": true,
-            "bin": {
-                "json5": "lib/cli.js"
-            }
-        },
         "node_modules/jsonfile": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -2780,18 +2701,6 @@
             "dev": true,
             "engines": {
                 "node": ">=6.11.5"
-            }
-        },
-        "node_modules/loader-utils": {
-            "version": "0.2.17",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-            "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-            "dev": true,
-            "dependencies": {
-                "big.js": "^3.1.3",
-                "emojis-list": "^2.0.0",
-                "json5": "^0.5.0",
-                "object-assign": "^4.0.1"
             }
         },
         "node_modules/locate-path": {
@@ -3267,15 +3176,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/once": {
@@ -3937,19 +3837,6 @@
                 "url": "https://github.com/chalk/slice-ansi?sponsor=1"
             }
         },
-        "node_modules/source-map": {
-            "version": "0.1.43",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-            "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "amdefine": ">=0.0.4"
-            },
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
         "node_modules/source-map-support": {
             "version": "0.4.18",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
@@ -3981,24 +3868,6 @@
             "dev": true,
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/string-replace-webpack-plugin": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/string-replace-webpack-plugin/-/string-replace-webpack-plugin-0.1.3.tgz",
-            "integrity": "sha1-c8ZX51nWbP6Arh4M8JGqJW0OcVw=",
-            "dev": true,
-            "dependencies": {
-                "async": "~0.2.10",
-                "loader-utils": "~0.2.3"
-            },
-            "optionalDependencies": {
-                "css-loader": "^0.9.1",
-                "file-loader": "^0.8.1",
-                "style-loader": "^0.8.3"
-            },
-            "peerDependencies": {
-                "webpack": "^1.4.2 || >=2.2.0"
             }
         },
         "node_modules/string-width": {
@@ -4050,16 +3919,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/style-loader": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.8.3.tgz",
-            "integrity": "sha1-9Pkut9tjdodI8VBlzWcA9aHIU1c=",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "loader-utils": "^0.2.5"
             }
         },
         "node_modules/supports-color": {
@@ -5516,13 +5375,6 @@
             "dev": true,
             "requires": {}
         },
-        "amdefine": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-            "dev": true,
-            "optional": true
-        },
         "ansi-colors": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -5591,22 +5443,10 @@
             "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
             "dev": true
         },
-        "async": {
-            "version": "0.2.10",
-            "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-            "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-            "dev": true
-        },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
-        },
-        "big.js": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-            "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
             "dev": true
         },
         "binary-extensions": {
@@ -5806,25 +5646,6 @@
             "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
             "dev": true
         },
-        "css-loader": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.9.1.tgz",
-            "integrity": "sha1-LhqgDOfjDvLGp6SzAKCAp8l54Nw=",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "csso": "1.3.x",
-                "loader-utils": "~0.2.2",
-                "source-map": "~0.1.38"
-            }
-        },
-        "csso": {
-            "version": "1.3.12",
-            "resolved": "https://registry.npmjs.org/csso/-/csso-1.3.12.tgz",
-            "integrity": "sha1-/GKGlKLTiTiqrEmWdTIY/TEc254=",
-            "dev": true,
-            "optional": true
-        },
         "debug": {
             "version": "4.3.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -5891,12 +5712,6 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-        },
-        "emojis-list": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-            "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-            "dev": true
         },
         "enhanced-resolve": {
             "version": "5.8.3",
@@ -6333,16 +6148,6 @@
                 "flat-cache": "^3.0.4"
             }
         },
-        "file-loader": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.8.5.tgz",
-            "integrity": "sha1-knXQMf54DyfUf19K8CvUNxPMFRs=",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "loader-utils": "~0.2.5"
-            }
-        },
         "fill-range": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -6766,12 +6571,6 @@
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
             "dev": true
         },
-        "json5": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-            "dev": true
-        },
         "jsonfile": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -6808,18 +6607,6 @@
             "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
             "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
             "dev": true
-        },
-        "loader-utils": {
-            "version": "0.2.17",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-            "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-            "dev": true,
-            "requires": {
-                "big.js": "^3.1.3",
-                "emojis-list": "^2.0.0",
-                "json5": "^0.5.0",
-                "object-assign": "^4.0.1"
-            }
         },
         "locate-path": {
             "version": "6.0.0",
@@ -7197,12 +6984,6 @@
             "requires": {
                 "path-key": "^3.0.0"
             }
-        },
-        "object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "dev": true
         },
         "once": {
             "version": "1.4.0",
@@ -7669,16 +7450,6 @@
                 "is-fullwidth-code-point": "^3.0.0"
             }
         },
-        "source-map": {
-            "version": "0.1.43",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-            "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "amdefine": ">=0.0.4"
-            }
-        },
         "source-map-support": {
             "version": "0.4.18",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
@@ -7707,19 +7478,6 @@
             "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
             "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
             "dev": true
-        },
-        "string-replace-webpack-plugin": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/string-replace-webpack-plugin/-/string-replace-webpack-plugin-0.1.3.tgz",
-            "integrity": "sha1-c8ZX51nWbP6Arh4M8JGqJW0OcVw=",
-            "dev": true,
-            "requires": {
-                "async": "~0.2.10",
-                "css-loader": "^0.9.1",
-                "file-loader": "^0.8.1",
-                "loader-utils": "~0.2.3",
-                "style-loader": "^0.8.3"
-            }
         },
         "string-width": {
             "version": "4.2.3",
@@ -7756,16 +7514,6 @@
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
             "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
             "dev": true
-        },
-        "style-loader": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.8.3.tgz",
-            "integrity": "sha1-9Pkut9tjdodI8VBlzWcA9aHIU1c=",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "loader-utils": "^0.2.5"
-            }
         },
         "supports-color": {
             "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
         "semver": "^7.3.5",
         "shx": "^0.3.3",
         "sinon": "^7.0.0",
-        "string-replace-webpack-plugin": "^0.1.3",
         "ts-node": "^3.3.0",
         "typescript": "^4.5.5",
         "typescript3": "npm:typescript@~3.7.0",

--- a/src/loadScriptFile.ts
+++ b/src/loadScriptFile.ts
@@ -16,7 +16,7 @@ export async function loadScriptFile(filePath: string, packageJson: PackageJson)
             throw new InternalException(`'${filePath}' could not be converted to file URL (${fileUrl.href})`);
         }
     } else {
-        script = require(filePath);
+        script = require(/* webpackIgnore: true */ filePath);
     }
     return script;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,14 +1,3 @@
-var StringReplacePlugin = require("string-replace-webpack-plugin");
-
-// replace require(expression) with __non_webpack_require__(expression)
-var dynamicRequire = {
-    pattern: /require\(([a-zA-Z0-9_\.]+)\)/,
-    replacement: function (match, p1, offset, string) {
-        console.log(`dynamic require ${p1} in ${match}`);
-        return `__non_webpack_require__(${p1})`;
-    }
-}
-
 module.exports = {
     entry: "./dist/src/Worker.js",
     output: {
@@ -21,22 +10,13 @@ module.exports = {
     node: {
         __dirname: false
     },
-    externals: [
-        'memcpy',
-    ],
+    externals: [],
     module: {
-        rules: [
-            {
-                // use dynamic require for require(expression)
-                // FunctionLoader.js -> require(userFunction)
-                test: /.*(FunctionLoader.js)$/,
-                use: StringReplacePlugin.replace({
-                    replacements: [ dynamicRequire ]
-                })
+        parser: {
+            javascript: {
+                commonjsMagicComments: true
             }
-        ]
+        }
     },
-    plugins: [
-        new StringReplacePlugin()
-    ]
+    plugins: []
 };


### PR DESCRIPTION
A Node.js test in the Core tools e2e [integration build](https://azfunc.visualstudio.com/Azure%20Functions/_build/results?buildId=67913&view=ms.vss-test-web.build-test-results-tab) is currently failing with an error like this:

> Cannot find module '/home/vsts/work/1/s/test/end-to-end/testFunctionApp/QueueTriggerAndOutput/index.js'

The bug only happens for the webpacked version of the worker and it came about because the webpack config hard-coded a file name and I moved some code out of that file in https://github.com/Azure/azure-functions-nodejs-worker/pull/576. The code in question does a 'require' on the user's scriptFilePath which is a dynamic value that webpack can't/shouldn't handle. I improved the webpack config so that we can use a simple comment in the code to tell webpack to ignore that 'require'. This should prevent similar bugs from happening in the future regardless of where we put this code.