### PR TITLE
Run e2e tests against webpacked worker

### DIFF
--- a/azure-pipelines/e2e-integration-test.yml
+++ b/azure-pipelines/e2e-integration-test.yml
@@ -48,6 +48,8 @@ steps:
     displayName: 'npm ci'
   - script: npm run build
     displayName: 'npm run build'
+  - script: npm run webpack
+    displayName: 'npm run webpack'
   - task: UseDotNet@2
     displayName: 'Install .NET 6'
     inputs:

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -109,6 +109,8 @@ jobs:
     displayName: 'npm ci'
   - script: npm run build
     displayName: 'npm run build'
+  - script: npm run webpack
+    displayName: 'npm run webpack'
   - task: UseDotNet@2
     displayName: 'Install .NET 6'
     inputs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
                 "typescript": "^4.5.5",
                 "typescript3": "npm:typescript@~3.7.0",
                 "typescript4": "npm:typescript@~4.0.0",
-                "webpack": "^5.53.0",
+                "webpack": "^5.72.1",
                 "webpack-cli": "^4.8.0"
             }
         },
@@ -455,9 +455,9 @@
             }
         },
         "node_modules/@types/eslint": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
-            "integrity": "sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==",
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.2.tgz",
+            "integrity": "sha512-Z1nseZON+GEnFjJc04sv4NSALGjhFwy6K0HXt7qsn5ArfAKtb63dXNJHf+1YW6IpOIYRBGUbu3GwJdj8DGnCjA==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "*",
@@ -465,9 +465,9 @@
             }
         },
         "node_modules/@types/eslint-scope": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.1.tgz",
-            "integrity": "sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==",
+            "version": "3.7.3",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.3.tgz",
+            "integrity": "sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==",
             "dev": true,
             "dependencies": {
                 "@types/eslint": "*",
@@ -475,9 +475,9 @@
             }
         },
         "node_modules/@types/estree": {
-            "version": "0.0.50",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-            "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
+            "version": "0.0.51",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
             "dev": true
         },
         "node_modules/@types/fs-extra": {
@@ -1467,9 +1467,9 @@
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.8.3",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
-            "integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
+            "integrity": "sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==",
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -2299,9 +2299,9 @@
             }
         },
         "node_modules/graceful-fs": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-            "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+            "version": "4.2.10",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
         },
         "node_modules/growl": {
             "version": "1.10.5",
@@ -2637,10 +2637,10 @@
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true
         },
-        "node_modules/json-parse-better-errors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+        "node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true
         },
         "node_modules/json-schema-traverse": {
@@ -4333,9 +4333,9 @@
             }
         },
         "node_modules/watchpack": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
-            "integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.1.tgz",
+            "integrity": "sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==",
             "dev": true,
             "dependencies": {
                 "glob-to-regexp": "^0.4.1",
@@ -4346,13 +4346,13 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.58.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.58.0.tgz",
-            "integrity": "sha512-xc2k5MLbR1iah24Z5xUm1nBh1PZXEdUnrX6YkTSOScq/VWbl5JCLREXJzGYqEAUbIO8tZI+Dzv82lGtnuUnVCQ==",
+            "version": "5.72.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.1.tgz",
+            "integrity": "sha512-dXG5zXCLspQR4krZVR6QgajnZOjW2K/djHvdcRaDQvsjV9z9vaW6+ja5dZOYbqBBjF6kGXka/2ZyxNdc+8Jung==",
             "dev": true,
             "dependencies": {
-                "@types/eslint-scope": "^3.7.0",
-                "@types/estree": "^0.0.50",
+                "@types/eslint-scope": "^3.7.3",
+                "@types/estree": "^0.0.51",
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/wasm-edit": "1.11.1",
                 "@webassemblyjs/wasm-parser": "1.11.1",
@@ -4360,21 +4360,21 @@
                 "acorn-import-assertions": "^1.7.6",
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.8.3",
+                "enhanced-resolve": "^5.9.3",
                 "es-module-lexer": "^0.9.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "glob-to-regexp": "^0.4.1",
-                "graceful-fs": "^4.2.4",
-                "json-parse-better-errors": "^1.0.2",
+                "graceful-fs": "^4.2.9",
+                "json-parse-even-better-errors": "^2.3.1",
                 "loader-runner": "^4.2.0",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
                 "schema-utils": "^3.1.0",
                 "tapable": "^2.1.1",
                 "terser-webpack-plugin": "^5.1.3",
-                "watchpack": "^2.2.0",
-                "webpack-sources": "^3.2.0"
+                "watchpack": "^2.3.1",
+                "webpack-sources": "^3.2.3"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -4480,9 +4480,9 @@
             }
         },
         "node_modules/webpack-sources": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.1.tgz",
-            "integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
             "dev": true,
             "engines": {
                 "node": ">=10.13.0"
@@ -4941,9 +4941,9 @@
             }
         },
         "@types/eslint": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
-            "integrity": "sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==",
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.2.tgz",
+            "integrity": "sha512-Z1nseZON+GEnFjJc04sv4NSALGjhFwy6K0HXt7qsn5ArfAKtb63dXNJHf+1YW6IpOIYRBGUbu3GwJdj8DGnCjA==",
             "dev": true,
             "requires": {
                 "@types/estree": "*",
@@ -4951,9 +4951,9 @@
             }
         },
         "@types/eslint-scope": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.1.tgz",
-            "integrity": "sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==",
+            "version": "3.7.3",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.3.tgz",
+            "integrity": "sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==",
             "dev": true,
             "requires": {
                 "@types/eslint": "*",
@@ -4961,9 +4961,9 @@
             }
         },
         "@types/estree": {
-            "version": "0.0.50",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-            "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
+            "version": "0.0.51",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
             "dev": true
         },
         "@types/fs-extra": {
@@ -5714,9 +5714,9 @@
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "enhanced-resolve": {
-            "version": "5.8.3",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
-            "integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
+            "integrity": "sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.2.4",
@@ -6305,9 +6305,9 @@
             }
         },
         "graceful-fs": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-            "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+            "version": "4.2.10",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
         },
         "growl": {
             "version": "1.10.5",
@@ -6553,10 +6553,10 @@
                 }
             }
         },
-        "json-parse-better-errors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+        "json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true
         },
         "json-schema-traverse": {
@@ -7815,9 +7815,9 @@
             }
         },
         "watchpack": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
-            "integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.1.tgz",
+            "integrity": "sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==",
             "dev": true,
             "requires": {
                 "glob-to-regexp": "^0.4.1",
@@ -7825,13 +7825,13 @@
             }
         },
         "webpack": {
-            "version": "5.58.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.58.0.tgz",
-            "integrity": "sha512-xc2k5MLbR1iah24Z5xUm1nBh1PZXEdUnrX6YkTSOScq/VWbl5JCLREXJzGYqEAUbIO8tZI+Dzv82lGtnuUnVCQ==",
+            "version": "5.72.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.1.tgz",
+            "integrity": "sha512-dXG5zXCLspQR4krZVR6QgajnZOjW2K/djHvdcRaDQvsjV9z9vaW6+ja5dZOYbqBBjF6kGXka/2ZyxNdc+8Jung==",
             "dev": true,
             "requires": {
-                "@types/eslint-scope": "^3.7.0",
-                "@types/estree": "^0.0.50",
+                "@types/eslint-scope": "^3.7.3",
+                "@types/estree": "^0.0.51",
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/wasm-edit": "1.11.1",
                 "@webassemblyjs/wasm-parser": "1.11.1",
@@ -7839,21 +7839,21 @@
                 "acorn-import-assertions": "^1.7.6",
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.8.3",
+                "enhanced-resolve": "^5.9.3",
                 "es-module-lexer": "^0.9.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "glob-to-regexp": "^0.4.1",
-                "graceful-fs": "^4.2.4",
-                "json-parse-better-errors": "^1.0.2",
+                "graceful-fs": "^4.2.9",
+                "json-parse-even-better-errors": "^2.3.1",
                 "loader-runner": "^4.2.0",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
                 "schema-utils": "^3.1.0",
                 "tapable": "^2.1.1",
                 "terser-webpack-plugin": "^5.1.3",
-                "watchpack": "^2.2.0",
-                "webpack-sources": "^3.2.0"
+                "watchpack": "^2.3.1",
+                "webpack-sources": "^3.2.3"
             }
         },
         "webpack-cli": {
@@ -7911,9 +7911,9 @@
             }
         },
         "webpack-sources": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.1.tgz",
-            "integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
             "dev": true
         },
         "which": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "typescript": "^4.5.5",
         "typescript3": "npm:typescript@~3.7.0",
         "typescript4": "npm:typescript@~4.0.0",
-        "webpack": "^5.53.0",
+        "webpack": "^5.72.1",
         "webpack-cli": "^4.8.0"
     },
     "homepage": "https://github.com/Azure/azure-functions-nodejs-worker",


### PR DESCRIPTION
I only discovered the bug in https://github.com/Azure/azure-functions-nodejs-worker/pull/579 because of an e2e test on the _core tools_ build. We should be running e2e tests for the worker on webpacked code so that we catch these kinds of bugs before they even get merged.

NOTE: The build is failing, but that's kind of the point. Once https://github.com/Azure/azure-functions-nodejs-worker/pull/579 is merged, the build with these changes will pass.