### PR TITLE
Fixes to release types pipeline

### DIFF
--- a/azure-pipelines/release-types.yml
+++ b/azure-pipelines/release-types.yml
@@ -4,7 +4,7 @@ parameters:
   type: string
   default: 'latest'
 - name: NpmPublishDryRun
-  displayName: 'Dry Run?'
+  displayName: 'Dry Run'
   type: boolean
   default: true
 
@@ -39,5 +39,5 @@ jobs:
       command: custom
       workingDir: '$(Pipeline.Workspace)/nodeWorkerCI/drop/types'
       verbose: true
-      customCommand: 'publish package.tgz --tag ${{ parameters.NpmPublishTag }} --dry-run ${{ parameters.NpmPublishDryRun }}'
+      customCommand: 'publish package.tgz --tag ${{ parameters.NpmPublishTag }} --dry-run ${{ lower(parameters.NpmPublishDryRun) }}'
       customEndpoint: 'TypeScript Types Publish'

--- a/azure-pipelines/release-types.yml
+++ b/azure-pipelines/release-types.yml
@@ -36,4 +36,4 @@ jobs:
       workingDir: '$(Pipeline.Workspace)/nodeWorkerCI/drop/types'
       verbose: true
       customCommand: 'publish package.tgz ${{ parameters.NpmPublishArgs }}'
-      publishEndpoint: 'TypeScript Types Publish'
+      customEndpoint: 'TypeScript Types Publish'

--- a/azure-pipelines/release-types.yml
+++ b/azure-pipelines/release-types.yml
@@ -1,8 +1,12 @@
 parameters:
-- name: NpmPublishArgs
-  displayName: 'NPM Publish Args'
+- name: NpmPublishTag
+  displayName: 'Tag'
   type: string
-  default: '--dry-run'
+  default: 'latest'
+- name: NpmPublishDryRun
+  displayName: 'Dry Run?'
+  type: boolean
+  default: true
 
 trigger: none
 pr: none
@@ -35,5 +39,5 @@ jobs:
       command: custom
       workingDir: '$(Pipeline.Workspace)/nodeWorkerCI/drop/types'
       verbose: true
-      customCommand: 'publish package.tgz ${{ parameters.NpmPublishArgs }}'
+      customCommand: 'publish package.tgz --tag ${{ parameters.NpmPublishTag }} --dry-run ${{ parameters.NpmPublishDryRun }}'
       customEndpoint: 'TypeScript Types Publish'


### PR DESCRIPTION
First, the publish step wasn't being authenticated correctly. Turns out I have to use `customEndpoint` instead of `publishEndpoint`, probably because `command` is set to `custom`

Second, the NpmPublishArgs parameter doesn't handle empty values well. If you delete the default value ('--dry-run'), it just uses the default value instead of passing an empty string. So rather than a free form args parameter I spilt it up into more explicit parameters