### PR TITLE
Allow Node 18 in the host

### DIFF
--- a/src/nodejsWorker.ts
+++ b/src/nodejsWorker.ts
@@ -4,8 +4,8 @@
 const logPrefix = 'LanguageWorkerConsoleLog';
 const errorPrefix = logPrefix + '[error] ';
 const warnPrefix = logPrefix + '[warn] ';
-const supportedVersions: string[] = ['v14', 'v16'];
-const devOnlyVersions: string[] = ['v15', 'v17', 'v18'];
+const supportedVersions: string[] = ['v14', 'v16', 'v18'];
+const devOnlyVersions: string[] = ['v15', 'v17'];
 let worker;
 
 // Try validating node version


### PR DESCRIPTION
I had it in the "devOnlyVersions" in https://github.com/Azure/azure-functions-nodejs-worker/pull/581, but I want it to be even easier to test in the host so I moved it to the "supportedVersions" array (even though it's not officially supported yet).

Related to https://github.com/Azure/azure-functions-nodejs-worker/issues/562