### PR TITLE
Temporarily remove app startup feature

### DIFF
--- a/src/eventHandlers/WorkerInitHandler.ts
+++ b/src/eventHandlers/WorkerInitHandler.ts
@@ -2,12 +2,9 @@
 // Licensed under the MIT License.
 
 import { access, constants } from 'fs';
-import { pathExists } from 'fs-extra';
 import * as path from 'path';
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
-import { loadScriptFile } from '../loadScriptFile';
-import { ensureErrorType, isError } from '../utils/ensureErrorType';
-import { nonNullProp } from '../utils/nonNull';
+import { isError } from '../utils/ensureErrorType';
 import { WorkerChannel } from '../WorkerChannel';
 import { EventHandler } from './EventHandler';
 import LogCategory = rpc.RpcLog.RpcLogCategory;
@@ -33,34 +30,9 @@ export class WorkerInitHandler extends EventHandler<'workerInitRequest', 'worker
         });
 
         logColdStartWarning(channel);
-        const functionAppDirectory = nonNullProp(msg, 'functionAppDirectory');
-        await channel.updatePackageJson(functionAppDirectory);
-
-        const entryPointFile = channel.packageJson.main;
-        if (entryPointFile) {
-            channel.log({
-                message: `Loading entry point "${entryPointFile}"`,
-                level: LogLevel.Debug,
-                logCategory: LogCategory.System,
-            });
-            try {
-                const entryPointFullPath = path.join(functionAppDirectory, entryPointFile);
-                if (!(await pathExists(entryPointFullPath))) {
-                    throw new Error(`file does not exist`);
-                }
-
-                await loadScriptFile(entryPointFullPath, channel.packageJson);
-                channel.log({
-                    message: `Loaded entry point "${entryPointFile}"`,
-                    level: LogLevel.Debug,
-                    logCategory: LogCategory.System,
-                });
-            } catch (err) {
-                const error = ensureErrorType(err);
-                error.isAzureFunctionsInternalException = true;
-                error.message = `Worker was unable to load entry point "${entryPointFile}": ${error.message}`;
-                throw error;
-            }
+        const functionAppDirectory = msg.functionAppDirectory;
+        if (functionAppDirectory) {
+            await channel.updatePackageJson(functionAppDirectory);
         }
 
         response.capabilities = {

--- a/test/eventHandlers/WorkerInitHandler.test.ts
+++ b/test/eventHandlers/WorkerInitHandler.test.ts
@@ -4,6 +4,7 @@
 import { expect } from 'chai';
 import * as escapeStringRegexp from 'escape-string-regexp';
 import 'mocha';
+import { ITestCallbackContext } from 'mocha';
 import * as mockFs from 'mock-fs';
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
 import { logColdStartWarning } from '../../src/eventHandlers/WorkerInitHandler';
@@ -213,7 +214,10 @@ describe('WorkerInitHandler', () => {
     });
 
     for (const extension of ['.js', '.mjs', '.cjs']) {
-        it(`Loads entry point (${extension})`, async () => {
+        it(`Loads entry point (${extension})`, async function (this: ITestCallbackContext) {
+            // Should be re-enabled after https://github.com/Azure/azure-functions-nodejs-worker/pull/577
+            this.skip();
+
             const fileName = `entryPointFiles/doNothing${extension}`;
             const expectedPackageJson = {
                 main: fileName,
@@ -236,7 +240,10 @@ describe('WorkerInitHandler', () => {
         });
     }
 
-    it('Fails for missing entry point', async () => {
+    it('Fails for missing entry point', async function (this: ITestCallbackContext) {
+        // Should be re-enabled after https://github.com/Azure/azure-functions-nodejs-worker/pull/577
+        this.skip();
+
         const fileName = 'entryPointFiles/missing.js';
         const expectedPackageJson = {
             main: fileName,
@@ -257,7 +264,10 @@ describe('WorkerInitHandler', () => {
         );
     });
 
-    it('Fails for invalid entry point', async () => {
+    it('Fails for invalid entry point', async function (this: ITestCallbackContext) {
+        // Should be re-enabled after https://github.com/Azure/azure-functions-nodejs-worker/pull/577
+        this.skip();
+
         const fileName = 'entryPointFiles/throwError.js';
         const expectedPackageJson = {
             main: fileName,


### PR DESCRIPTION
The cutoff for the next host release is the 15th. I really need to get Node 18 unblocked and the only reason I haven't integrated with the host already is because the [app startup](https://github.com/Azure/azure-functions-nodejs-worker/pull/576) feature intended to go out with this release has problems with worker specialization. It will be fixed with [this PR](https://github.com/Azure/azure-functions-nodejs-worker/pull/577), but that's still not ready to be merged and it's too risky to try squeezing that in without the proper time & testing.