### PR TITLE
Fix environment variables casing bug

### DIFF
--- a/src/eventHandlers/FunctionEnvironmentReloadHandler.ts
+++ b/src/eventHandlers/FunctionEnvironmentReloadHandler.ts
@@ -34,7 +34,11 @@ export class FunctionEnvironmentReloadHandler extends EventHandler<
             logCategory: LogCategory.System,
         });
 
-        process.env = Object.assign({}, msg.environmentVariables);
+        // reset existing env vars
+        Object.keys(process.env).map((key) => delete process.env[key]);
+        // set new env vars
+        Object.assign(process.env, msg.environmentVariables);
+
         // Change current working directory
         if (msg.functionAppDirectory) {
             channel.log({

--- a/test/eventHandlers/FunctionEnvironmentReloadHandler.test.ts
+++ b/test/eventHandlers/FunctionEnvironmentReloadHandler.test.ts
@@ -103,28 +103,31 @@ describe('FunctionEnvironmentReloadHandler', () => {
         expect(process.env.PlaceholderVariable).to.be.undefined;
     });
 
-    if (process.platform === 'win32') {
-        it('preserves case insensitivity of environment variables on Windows', async () => {
-            process.env.PlaceholderVariable = 'TRUE';
-            stream.addTestMessage({
-                requestId: 'id',
-                functionEnvironmentReloadRequest: {
-                    environmentVariables: {
-                        hello: 'world',
-                        SystemDrive: 'Q:',
-                    },
-                    functionAppDirectory: null,
+    it('preserves OS-specific casing behavior of environment variables', async () => {
+        process.env.PlaceholderVariable = 'TRUE';
+        stream.addTestMessage({
+            requestId: 'id',
+            functionEnvironmentReloadRequest: {
+                environmentVariables: {
+                    hello: 'world',
+                    SystemDrive: 'Q:',
                 },
-            });
-            await stream.assertCalledWith(Msg.reloadEnvVarsLog(2), Msg.reloadSuccess);
-            expect(process.env.hello).to.equal('world');
-            expect(process.env.HeLlO).to.equal('world');
-            expect(process.env.SystemDrive).to.equal('Q:');
-            expect(process.env.systemdrive).to.equal('Q:');
-            expect(process.env.PlaceholderVariable).to.be.undefined;
-            expect(process.env.placeholdervariable).to.be.undefined;
+                functionAppDirectory: null,
+            },
         });
-    }
+        await stream.assertCalledWith(Msg.reloadEnvVarsLog(2), Msg.reloadSuccess);
+        expect(process.env.hello).to.equal('world');
+        expect(process.env.SystemDrive).to.equal('Q:');
+        expect(process.env.PlaceholderVariable).to.be.undefined;
+        expect(process.env.placeholdervariable).to.be.undefined;
+        if (process.platform === 'win32') {
+            expect(process.env.HeLlO).to.equal('world');
+            expect(process.env.systemdrive).to.equal('Q:');
+        } else {
+            expect(process.env.HeLlO).to.be.undefined;
+            expect(process.env.systemdrive).to.be.undefined;
+        }
+    });
 
     it('reloading environment variables removes existing environment variables', async () => {
         process.env.PlaceholderVariable = 'TRUE';

--- a/test/eventHandlers/FunctionEnvironmentReloadHandler.test.ts
+++ b/test/eventHandlers/FunctionEnvironmentReloadHandler.test.ts
@@ -103,26 +103,28 @@ describe('FunctionEnvironmentReloadHandler', () => {
         expect(process.env.PlaceholderVariable).to.be.undefined;
     });
 
-    it('preserves case insensitivity of environment variables', async () => {
-        process.env.PlaceholderVariable = 'TRUE';
-        stream.addTestMessage({
-            requestId: 'id',
-            functionEnvironmentReloadRequest: {
-                environmentVariables: {
-                    hello: 'world',
-                    SystemDrive: 'Q:',
+    if (process.platform === 'win32') {
+        it('preserves case insensitivity of environment variables on Windows', async () => {
+            process.env.PlaceholderVariable = 'TRUE';
+            stream.addTestMessage({
+                requestId: 'id',
+                functionEnvironmentReloadRequest: {
+                    environmentVariables: {
+                        hello: 'world',
+                        SystemDrive: 'Q:',
+                    },
+                    functionAppDirectory: null,
                 },
-                functionAppDirectory: null,
-            },
+            });
+            await stream.assertCalledWith(Msg.reloadEnvVarsLog(2), Msg.reloadSuccess);
+            expect(process.env.hello).to.equal('world');
+            expect(process.env.HeLlO).to.equal('world');
+            expect(process.env.SystemDrive).to.equal('Q:');
+            expect(process.env.systemdrive).to.equal('Q:');
+            expect(process.env.PlaceholderVariable).to.be.undefined;
+            expect(process.env.placeholdervariable).to.be.undefined;
         });
-        await stream.assertCalledWith(Msg.reloadEnvVarsLog(2), Msg.reloadSuccess);
-        expect(process.env.hello).to.equal('world');
-        expect(process.env.HeLlO).to.equal('world');
-        expect(process.env.SystemDrive).to.equal('Q:');
-        expect(process.env.systemdrive).to.equal('Q:');
-        expect(process.env.PlaceholderVariable).to.be.undefined;
-        expect(process.env.placeholdervariable).to.be.undefined;
-    });
+    }
 
     it('reloading environment variables removes existing environment variables', async () => {
         process.env.PlaceholderVariable = 'TRUE';

--- a/test/startApp.test.ts
+++ b/test/startApp.test.ts
@@ -48,13 +48,13 @@ describe('startApp', () => {
 
     before(async () => {
         originalCwd = process.cwd();
-        originalEnv = process.env;
+        originalEnv = { ...process.env };
         ({ stream, channel } = beforeEventHandlerSuite());
         coreApi = await import('@azure/functions-core');
     });
 
     after(() => {
-        process.env = originalEnv;
+        Object.assign(process.env, originalEnv);
     });
 
     afterEach(async () => {


### PR DESCRIPTION
Resolves #600. Case insensitive behavior should only exist on Windows. Simply deleting and resetting keys on the `process.env` object allows it to maintain its default behavior, allowing case insensitivity on Windows and disallowing it on Mac/Linux