### PR TITLE
Add worker metadata to init response

### DIFF
--- a/src/eventHandlers/WorkerInitHandler.ts
+++ b/src/eventHandlers/WorkerInitHandler.ts
@@ -4,6 +4,7 @@
 import { access, constants } from 'fs';
 import * as path from 'path';
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
+import { version as workerVersion } from '../constants';
 import { startApp } from '../startApp';
 import { isError } from '../utils/ensureErrorType';
 import { nonNullProp } from '../utils/nonNull';
@@ -19,7 +20,14 @@ export class WorkerInitHandler extends EventHandler<'workerInitRequest', 'worker
     readonly responseName = 'workerInitResponse';
 
     getDefaultResponse(_msg: rpc.IWorkerInitRequest): rpc.IWorkerInitResponse {
-        return {};
+        return {
+            workerMetadata: {
+                runtimeName: 'node',
+                runtimeVersion: process.version,
+                workerBitness: process.arch,
+                workerVersion,
+            },
+        };
     }
 
     async handleEvent(channel: WorkerChannel, msg: rpc.IWorkerInitRequest): Promise<rpc.IWorkerInitResponse> {


### PR DESCRIPTION
Example metadata:
![Screen Shot 2022-07-22 at 10 46 50 AM](https://user-images.githubusercontent.com/11282622/180497734-076b35ec-9c87-466b-b2a3-578dedf6107b.png)



Fixes https://github.com/Azure/azure-functions-nodejs-worker/issues/592