### PR TITLE
Bump version to 3.5.0

### DIFF
--- a/Worker.nuspec
+++ b/Worker.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Microsoft.Azure.Functions.NodeJsWorker</id>
-    <version>3.4.0$prereleaseSuffix$</version>
+    <version>3.5.0$prereleaseSuffix$</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-functions-nodejs-worker",
-    "version": "3.4.0",
+    "version": "3.5.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-functions-nodejs-worker",
-            "version": "3.4.0",
+            "version": "3.5.0",
             "license": "(MIT OR Apache-2.0)",
             "dependencies": {
                 "@azure/functions": "^3.5.0-alpha.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-functions-nodejs-worker",
     "author": "Microsoft Corporation",
-    "version": "3.4.0",
+    "version": "3.5.0",
     "description": "Microsoft Azure Functions NodeJS Worker",
     "license": "(MIT OR Apache-2.0)",
     "dependencies": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-export const version = '3.4.0';
+export const version = '3.5.0';


### PR DESCRIPTION
Should've done this right after [3.4.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.4.0) was released, but forgot