### PR TITLE
Make invocationContext readonly in hooks

### DIFF
--- a/src/eventHandlers/InvocationHandler.ts
+++ b/src/eventHandlers/InvocationHandler.ts
@@ -67,7 +67,12 @@ export class InvocationHandler extends EventHandler<'invocationRequest', 'invoca
             set appHookData(_obj) {
                 throw new ReadOnlyError('appHookData');
             },
-            invocationContext: context,
+            get invocationContext() {
+                return context;
+            },
+            set invocationContext(_obj) {
+                throw new ReadOnlyError('invocationContext');
+            },
             functionCallback: callback,
             inputs,
         };
@@ -95,7 +100,12 @@ export class InvocationHandler extends EventHandler<'invocationRequest', 'invoca
             set appHookData(_obj) {
                 throw new ReadOnlyError('appHookData');
             },
-            invocationContext: context,
+            get invocationContext() {
+                return context;
+            },
+            set invocationContext(_obj) {
+                throw new ReadOnlyError('invocationContext');
+            },
             inputs,
             result: null,
             error: null,

--- a/test/eventHandlers/InvocationHandler.test.ts
+++ b/test/eventHandlers/InvocationHandler.test.ts
@@ -819,7 +819,7 @@ describe('InvocationHandler', () => {
         expect(hookData).to.equal('prepost');
     });
 
-    it('enforces readonly property of hookData and appHookData in pre and post invocation hooks', async () => {
+    it('enforces readonly properties in pre and post invocation hooks', async () => {
         loader.getFunction.returns({
             metadata: Binding.queue,
             callback: async () => {},
@@ -840,6 +840,12 @@ describe('InvocationHandler', () => {
                         foo: 'bar',
                     };
                 }).to.throw(`Cannot assign to read only property 'appHookData'`);
+                expect(() => {
+                    // @ts-expect-error: setting readonly property
+                    context.invocationContext = {
+                        foo: 'bar',
+                    };
+                }).to.throw(`Cannot assign to read only property 'invocationContext'`);
                 hookData += 'pre';
             })
         );
@@ -859,6 +865,12 @@ describe('InvocationHandler', () => {
                         foo: 'bar',
                     };
                 }).to.throw(`Cannot assign to read only property 'appHookData'`);
+                expect(() => {
+                    // @ts-expect-error: setting readonly property
+                    context.invocationContext = {
+                        foo: 'bar',
+                    };
+                }).to.throw(`Cannot assign to read only property 'invocationContext'`);
                 hookData += 'post';
             })
         );

--- a/types-core/index.d.ts
+++ b/types-core/index.d.ts
@@ -60,12 +60,12 @@ declare module '@azure/functions-core' {
     interface HookContext {
         /**
          * The recommended place to share data between hooks in the same scope (app-level vs invocation-level)
-         * This object is readonly and attempting to overwrite it will throw an error
+         * This object is readonly. You may modify it, but attempting to overwrite it will throw an error
          */
         readonly hookData: HookData;
         /**
          * The recommended place to share data across scopes for all hooks
-         * This object is readonly and attempting to overwrite it will throw an error
+         * This object is readonly. You may modify it, but attempting to overwrite it will throw an error
          */
         readonly appHookData: HookData;
     }
@@ -77,8 +77,9 @@ declare module '@azure/functions-core' {
     interface PreInvocationContext extends HookContext {
         /**
          * The context object passed to the function
+         * This object is readonly. You may modify it, but attempting to overwrite it will throw an error
          */
-        invocationContext: unknown;
+        readonly invocationContext: unknown;
 
         /**
          * The input values for this specific invocation. Changes to this array _will_ affect the inputs passed to your function
@@ -98,8 +99,9 @@ declare module '@azure/functions-core' {
     interface PostInvocationContext extends HookContext {
         /**
          * The context object passed to the function
+         * This object is readonly. You may modify it, but attempting to overwrite it will throw an error
          */
-        invocationContext: unknown;
+        readonly invocationContext: unknown;
 
         /**
          * The input values for this specific invocation


### PR DESCRIPTION
People can modify it at will, but too important to have them completely overwrite it