### PR TITLE
Treat failure to load entry point as warning instead of error

### DIFF
--- a/src/startApp.ts
+++ b/src/startApp.ts
@@ -64,45 +64,11 @@ async function loadEntryPointFile(functionAppDirectory: string, channel: WorkerC
             }
         } catch (err) {
             const error = ensureErrorType(err);
-            const message = `Worker was unable to load entry point "${entryPointPattern}": ${error.message}`;
-
-            // If this is an old existing app, we can't throw an error about the entrypoint for backwards compat reasons
-            // More info here: https://github.com/Azure/azure-functions-nodejs-worker/issues/630
-            // However, if we determine this is the new programming model, we will do the "proper" thing and throw an error
-            if (await isNewProgrammingModel(functionAppDirectory)) {
-                channel.log({
-                    message:
-                        'No "function.json" files found, so assuming this app uses a programming model requiring a valid "main" field in "package.json".',
-                    level: LogLevel.Warning,
-                    logCategory: LogCategory.System,
-                });
-
-                error.isAzureFunctionsSystemError = true;
-                error.message = message;
-                throw error;
-            } else {
-                channel.log({
-                    message,
-                    level: LogLevel.Warning,
-                    logCategory: LogCategory.System,
-                });
-            }
+            channel.log({
+                message: `Worker was unable to load entry point "${entryPointPattern}": ${error.message}`,
+                level: LogLevel.Warning,
+                logCategory: LogCategory.System,
+            });
         }
-    }
-}
-
-/**
- * Best effort to determine if this is the new programming model based on the existence of "function.json" files
- * Defaults to false if we can't figure it out
- */
-async function isNewProgrammingModel(functionAppDirectory: string): Promise<boolean> {
-    try {
-        const files = await globby('*/function.json', {
-            cwd: functionAppDirectory,
-            caseSensitiveMatch: false,
-        });
-        return files.length === 0;
-    } catch {
-        return false;
     }
 }

--- a/src/startApp.ts
+++ b/src/startApp.ts
@@ -64,9 +64,11 @@ async function loadEntryPointFile(functionAppDirectory: string, channel: WorkerC
             }
         } catch (err) {
             const error = ensureErrorType(err);
-            error.isAzureFunctionsSystemError = true;
-            error.message = `Worker was unable to load entry point "${entryPointPattern}": ${error.message}`;
-            throw error;
+            channel.log({
+                message: `Worker was unable to load entry point "${entryPointPattern}": ${error.message}`,
+                level: LogLevel.Warning,
+                logCategory: LogCategory.System,
+            });
         }
     }
 }

--- a/test/eventHandlers/WorkerInitHandler.test.ts
+++ b/test/eventHandlers/WorkerInitHandler.test.ts
@@ -137,6 +137,15 @@ export namespace Msg {
             logCategory: LogCategory.System,
         },
     };
+
+    export const noFunctionJsonWarning: rpc.IStreamingMessage = {
+        rpcLog: {
+            message:
+                'No "function.json" files found, so assuming this app uses a programming model requiring a valid "main" field in "package.json".',
+            level: LogLevel.Warning,
+            logCategory: LogCategory.System,
+        },
+    };
 }
 
 describe('WorkerInitHandler', () => {
@@ -283,13 +292,16 @@ describe('WorkerInitHandler', () => {
         );
     });
 
-    it('Fails for missing entry point', async function (this: ITestCallbackContext) {
+    it('Warns for missing entry point in old programming model', async function (this: ITestCallbackContext) {
         const fileName = 'entryPointFiles/missing.js';
         const expectedPackageJson = {
             main: fileName,
         };
         mockFs({
             [__dirname]: {
+                HttpTrigger1: {
+                    'function.json': '{}',
+                },
                 'package.json': JSON.stringify(expectedPackageJson),
             },
         });
@@ -299,13 +311,16 @@ describe('WorkerInitHandler', () => {
         await stream.assertCalledWith(Msg.receivedInitLog, Msg.warning(warningMessage), Msg.response);
     });
 
-    it('Fails for invalid entry point', async function (this: ITestCallbackContext) {
+    it('Warns for invalid entry point in old programming model', async function (this: ITestCallbackContext) {
         const fileName = 'entryPointFiles/throwError.js';
         const expectedPackageJson = {
             main: fileName,
         };
         mockFs({
             [__dirname]: {
+                HttpTrigger1: {
+                    'fuNcTion.json': '{}', // try different casing as well
+                },
                 'package.json': JSON.stringify(expectedPackageJson),
                 // 'require' and 'mockFs' don't play well together so we need these files in both the mock and real file systems
                 entryPointFiles: mockFs.load(path.join(__dirname, 'entryPointFiles')),
@@ -319,6 +334,51 @@ describe('WorkerInitHandler', () => {
             Msg.loadingEntryPoint(fileName),
             Msg.warning(warningMessage),
             Msg.response
+        );
+    });
+
+    it('Fails for missing entry point in new programming model', async () => {
+        const fileName = 'entryPointFiles/missing.js';
+        const expectedPackageJson = {
+            main: fileName,
+        };
+        mockFs({
+            [__dirname]: {
+                'package.json': JSON.stringify(expectedPackageJson),
+            },
+        });
+
+        stream.addTestMessage(Msg.init(__dirname));
+        const errorMessage = `Worker was unable to load entry point "${fileName}": Found zero files matching the supplied pattern`;
+        await stream.assertCalledWith(
+            Msg.receivedInitLog,
+            Msg.noFunctionJsonWarning,
+            Msg.error(errorMessage),
+            Msg.failedResponse(fileName, errorMessage)
+        );
+    });
+
+    it('Fails for invalid entry point in new programming model', async () => {
+        const fileName = 'entryPointFiles/throwError.js';
+        const expectedPackageJson = {
+            main: fileName,
+        };
+        mockFs({
+            [__dirname]: {
+                'package.json': JSON.stringify(expectedPackageJson),
+                // 'require' and 'mockFs' don't play well together so we need these files in both the mock and real file systems
+                entryPointFiles: mockFs.load(path.join(__dirname, 'entryPointFiles')),
+            },
+        });
+
+        stream.addTestMessage(Msg.init(__dirname));
+        const errorMessage = `Worker was unable to load entry point "${fileName}": test`;
+        await stream.assertCalledWith(
+            Msg.receivedInitLog,
+            Msg.loadingEntryPoint(fileName),
+            Msg.noFunctionJsonWarning,
+            Msg.error(errorMessage),
+            Msg.failedResponse(fileName, errorMessage)
         );
     });
 });

--- a/test/eventHandlers/WorkerInitHandler.test.ts
+++ b/test/eventHandlers/WorkerInitHandler.test.ts
@@ -295,12 +295,8 @@ describe('WorkerInitHandler', () => {
         });
 
         stream.addTestMessage(Msg.init(__dirname));
-        const errorMessage = `Worker was unable to load entry point "${fileName}": Found zero files matching the supplied pattern`;
-        await stream.assertCalledWith(
-            Msg.receivedInitLog,
-            Msg.error(errorMessage),
-            Msg.failedResponse(fileName, errorMessage)
-        );
+        const warningMessage = `Worker was unable to load entry point "${fileName}": Found zero files matching the supplied pattern`;
+        await stream.assertCalledWith(Msg.receivedInitLog, Msg.warning(warningMessage), Msg.response);
     });
 
     it('Fails for invalid entry point', async function (this: ITestCallbackContext) {
@@ -317,12 +313,12 @@ describe('WorkerInitHandler', () => {
         });
 
         stream.addTestMessage(Msg.init(__dirname));
-        const errorMessage = `Worker was unable to load entry point "${fileName}": test`;
+        const warningMessage = `Worker was unable to load entry point "${fileName}": test`;
         await stream.assertCalledWith(
             Msg.receivedInitLog,
             Msg.loadingEntryPoint(fileName),
-            Msg.error(errorMessage),
-            Msg.failedResponse(fileName, errorMessage)
+            Msg.warning(warningMessage),
+            Msg.response
         );
     });
 });


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-nodejs-worker/issues/630

Most of the apps we saw with an error had "main" set to index.js but that file didn't exist. We don't don't want to break those existing users, so we will convert the error to a warning. ~~However, we still want to throw an error in the new programming model (which obviously doesn't have any existing users) - so we will use the existence of "function.json" files to determine which model is being used and act accordingly.~~ EDIT: Changed our mind on this.