### PR TITLE
Support multiple workers with new indexing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,7 @@
                 "blocked-at": "^1.2.0",
                 "fs-extra": "^10.0.1",
                 "globby": "^11.0.0",
-                "minimist": "^1.2.5",
-                "uuid": "^8.3.2"
+                "minimist": "^1.2.5"
             },
             "devDependencies": {
                 "@types/blocked-at": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
         "blocked-at": "^1.2.0",
         "fs-extra": "^10.0.1",
         "globby": "^11.0.0",
-        "minimist": "^1.2.5",
-        "uuid": "^8.3.2"
+        "minimist": "^1.2.5"
     },
     "devDependencies": {
         "@types/blocked-at": "^1.0.1",

--- a/src/LegacyFunctionLoader.ts
+++ b/src/LegacyFunctionLoader.ts
@@ -11,7 +11,7 @@ import { RegisteredFunction } from './WorkerChannel';
 
 export interface ILegacyFunctionLoader {
     load(functionId: string, metadata: rpc.IRpcFunctionMetadata, packageJson: PackageJson): Promise<void>;
-    getFunction(functionId: string): RegisteredFunction;
+    getFunction(functionId: string): RegisteredFunction | undefined;
 }
 
 interface LegacyRegisteredFunction extends RegisteredFunction {
@@ -31,7 +31,7 @@ export class LegacyFunctionLoader implements ILegacyFunctionLoader {
         this.#loadedFunctions[functionId] = { metadata, callback, thisArg };
     }
 
-    getFunction(functionId: string): RegisteredFunction {
+    getFunction(functionId: string): RegisteredFunction | undefined {
         const loadedFunction = this.#loadedFunctions[functionId];
         if (loadedFunction) {
             return {
@@ -40,7 +40,7 @@ export class LegacyFunctionLoader implements ILegacyFunctionLoader {
                 callback: loadedFunction.callback.bind(loadedFunction.thisArg),
             };
         } else {
-            throw new AzFuncSystemError(`Function code for '${functionId}' is not loaded and cannot be invoked.`);
+            return undefined;
         }
     }
 }

--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -42,8 +42,8 @@ export function startNodeWorker(args) {
         throw error;
     }
 
-    const channel = new WorkerChannel(eventStream, new LegacyFunctionLoader());
-    setupEventStream(workerId, channel);
+    const channel = new WorkerChannel(workerId, eventStream, new LegacyFunctionLoader());
+    setupEventStream(channel);
     setupCoreModule(channel);
 
     eventStream.write({

--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -17,6 +17,7 @@ export interface RegisteredFunction {
 }
 
 export class WorkerChannel {
+    workerId: string;
     eventStream: IEventStream;
     legacyFunctionLoader: ILegacyFunctionLoader;
     packageJson: PackageJson;
@@ -47,9 +48,11 @@ export class WorkerChannel {
     #appStartHooks: HookCallback[] = [];
     #appTerminateHooks: HookCallback[] = [];
     functions: { [id: string]: RegisteredFunction } = {};
-    hasIndexedFunctions = false;
+    workerIndexingLocked = false;
+    isUsingWorkerIndexing = false;
 
-    constructor(eventStream: IEventStream, legacyFunctionLoader: ILegacyFunctionLoader) {
+    constructor(workerId: string, eventStream: IEventStream, legacyFunctionLoader: ILegacyFunctionLoader) {
+        this.workerId = workerId;
         this.eventStream = eventStream;
         this.legacyFunctionLoader = legacyFunctionLoader;
         this.packageJson = {};

--- a/src/eventHandlers/FunctionsMetadataHandler.ts
+++ b/src/eventHandlers/FunctionsMetadataHandler.ts
@@ -20,10 +20,12 @@ export class FunctionsMetadataHandler extends EventHandler<'functionsMetadataReq
         channel: WorkerChannel,
         msg: rpc.IFunctionsMetadataRequest
     ): Promise<rpc.IFunctionMetadataResponse> {
+        channel.workerIndexingLocked = true;
+
         const response = this.getDefaultResponse(msg);
 
         channel.log({
-            message: 'Received FunctionsMetadataRequest',
+            message: `Worker ${channel.workerId} received FunctionsMetadataRequest`,
             level: LogLevel.Debug,
             logCategory: LogCategory.System,
         });
@@ -33,8 +35,6 @@ export class FunctionsMetadataHandler extends EventHandler<'functionsMetadataReq
             response.useDefaultMetadataIndexing = false;
             response.functionMetadataResults = functions.map((f) => f.metadata);
         }
-
-        channel.hasIndexedFunctions = true;
 
         return response;
     }

--- a/src/eventHandlers/WorkerInitHandler.ts
+++ b/src/eventHandlers/WorkerInitHandler.ts
@@ -34,7 +34,7 @@ export class WorkerInitHandler extends EventHandler<'workerInitRequest', 'worker
         const response = this.getDefaultResponse(msg);
 
         channel.log({
-            message: 'Received WorkerInitRequest',
+            message: `Worker ${channel.workerId} received WorkerInitRequest`,
             level: LogLevel.Debug,
             logCategory: LogCategory.System,
         });

--- a/test/LegacyFunctionLoader.test.ts
+++ b/test/LegacyFunctionLoader.test.ts
@@ -7,6 +7,7 @@ import 'mocha';
 import * as mock from 'mock-require';
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
 import { LegacyFunctionLoader } from '../src/LegacyFunctionLoader';
+import { nonNullValue } from '../src/utils/nonNull';
 const expect = chai.expect;
 chai.use(chaiAsPromised);
 
@@ -52,9 +53,7 @@ describe('LegacyFunctionLoader', () => {
             {}
         );
 
-        expect(() => {
-            loader.getFunction('functionId');
-        }).to.throw("Function code for 'functionId' is not loaded and cannot be invoked.");
+        expect(loader.getFunction('functionId')).to.be.undefined;
     });
 
     it('throws unable to determine function entry point with entryPoint name', async () => {
@@ -118,8 +117,7 @@ describe('LegacyFunctionLoader', () => {
             {}
         );
 
-        const userFunction = loader.getFunction('functionId');
-
+        const userFunction = nonNullValue(loader.getFunction('functionId'));
         userFunction.callback(context, (results) => {
             expect(results).to.eql({ prop: true });
         });
@@ -137,7 +135,7 @@ describe('LegacyFunctionLoader', () => {
             {}
         );
 
-        const userFunction = loader.getFunction('functionId');
+        const userFunction = nonNullValue(loader.getFunction('functionId'));
         const result = userFunction.callback({});
 
         expect(result).to.be.not.an('undefined');
@@ -156,10 +154,10 @@ describe('LegacyFunctionLoader', () => {
             {}
         );
 
-        const userFunction = loader.getFunction('functionId').callback;
+        const userFunction = nonNullValue(loader.getFunction('functionId')).callback;
         Object.assign(userFunction, { hello: 'world' });
 
-        const userFunction2 = loader.getFunction('functionId').callback;
+        const userFunction2 = nonNullValue(loader.getFunction('functionId')).callback;
 
         expect(userFunction).to.not.equal(userFunction2);
         expect(userFunction['hello']).to.equal('world');

--- a/test/eventHandlers/FunctionEnvironmentReloadHandler.test.ts
+++ b/test/eventHandlers/FunctionEnvironmentReloadHandler.test.ts
@@ -35,7 +35,7 @@ export namespace Msg {
 
     export const noHandlerRpcLog: rpc.IStreamingMessage = {
         rpcLog: {
-            message: "Worker workerId had no handler for message 'undefined'",
+            message: "Worker 00000000-0000-0000-0000-000000000000 had no handler for message 'undefined'",
             level: LogLevel.Error,
             logCategory: LogCategory.System,
         },

--- a/test/eventHandlers/FunctionLoadHandler.test.ts
+++ b/test/eventHandlers/FunctionLoadHandler.test.ts
@@ -11,6 +11,16 @@ import { TestEventStream } from './TestEventStream';
 import LogCategory = rpc.RpcLog.RpcLogCategory;
 import LogLevel = rpc.RpcLog.Level;
 
+namespace Msg {
+    export const receivedLoadLog: rpc.IStreamingMessage = {
+        rpcLog: {
+            message: 'Worker 00000000-0000-0000-0000-000000000000 received FunctionLoadRequest',
+            level: LogLevel.Debug,
+            logCategory: LogCategory.System,
+        },
+    };
+}
+
 describe('FunctionLoadHandler', () => {
     let stream: TestEventStream;
     let loader: sinon.SinonStubbedInstance<LegacyFunctionLoader>;
@@ -31,7 +41,7 @@ describe('FunctionLoadHandler', () => {
                 metadata: {},
             },
         });
-        await stream.assertCalledWith({
+        await stream.assertCalledWith(Msg.receivedLoadLog, {
             requestId: 'id',
             functionLoadResponse: {
                 functionId: 'funcId',
@@ -70,7 +80,7 @@ describe('FunctionLoadHandler', () => {
                 },
             };
 
-            await stream.assertCalledWith(errorRpcLog, {
+            await stream.assertCalledWith(Msg.receivedLoadLog, errorRpcLog, {
                 requestId: 'id',
                 functionLoadResponse: {
                     functionId: 'funcId',

--- a/test/eventHandlers/WorkerInitHandler.test.ts
+++ b/test/eventHandlers/WorkerInitHandler.test.ts
@@ -83,7 +83,7 @@ export namespace Msg {
 
     export const receivedInitLog: rpc.IStreamingMessage = {
         rpcLog: {
-            message: 'Received WorkerInitRequest',
+            message: 'Worker 00000000-0000-0000-0000-000000000000 received WorkerInitRequest',
             level: LogLevel.Debug,
             logCategory: LogCategory.System,
         },

--- a/test/eventHandlers/beforeEventHandlerSuite.ts
+++ b/test/eventHandlers/beforeEventHandlerSuite.ts
@@ -20,8 +20,8 @@ export function beforeEventHandlerSuite() {
     if (!testWorkerData) {
         const stream = new TestEventStream();
         const loader = sinon.createStubInstance<LegacyFunctionLoader>(LegacyFunctionLoader);
-        const channel = new WorkerChannel(stream, loader);
-        setupEventStream('workerId', channel);
+        const channel = new WorkerChannel('00000000-0000-0000-0000-000000000000', stream, loader);
+        setupEventStream(channel);
         setupCoreModule(channel);
         testWorkerData = { stream, loader, channel };
         // Clear out logs that happened during setup, so that they don't affect whichever test runs first

--- a/types-core/index.d.ts
+++ b/types-core/index.d.ts
@@ -23,12 +23,21 @@ declare module '@azure/functions-core' {
 
     /**
      * A slimmed down version of `RpcFunctionMetadata` that includes the minimum amount of information needed to register a function
+     * NOTE: All properties on this object need to be deterministic to support the multiple worker scenario. More info here: https://github.com/Azure/azure-functions-nodejs-worker/issues/638
      */
     interface FunctionMetadata {
         /**
-         * The function name
+         * The function name, used for display and tracking purposes
+         * Must be unique within the app
          */
         name: string;
+
+        /**
+         * The function id, used for tracking purposes
+         * Must be unique within the app
+         * If not specified, the function name will be used
+         */
+        functionId?: string;
 
         /**
          * A dictionary of binding name to binding info


### PR DESCRIPTION
Related to https://github.com/Azure/azure-functions-nodejs-worker/issues/638

This PR does a few things:
1. Always include worker id when logging that we received a request. This makes debugging the "multiple worker" scenario so much easier
2. Use function name as function id instead of a random guid. This ensures each worker returns the same thing
3. Allow the library package to specify both the name and id. This just gives us more flexibility to fix things on the library-side instead of worker-side if necessary down the line
4. Adjust the worker indexing booleans on `WorkerChannel` for two reasons:
    a. To account for the fact that only the 1st worker gets the FunctionsMetadataRequest
    b. To more explicitly separate the worker-indexing and legacy scenarios and avoid any mingling