### PR TITLE
Allow Node.js v19 for local development

### DIFF
--- a/src/nodejsWorker.ts
+++ b/src/nodejsWorker.ts
@@ -5,7 +5,7 @@ const logPrefix = 'LanguageWorkerConsoleLog';
 const errorPrefix = logPrefix + '[error] ';
 const warnPrefix = logPrefix + '[warn] ';
 const supportedVersions: string[] = ['v14', 'v16', 'v18'];
-const devOnlyVersions: string[] = ['v15', 'v17'];
+const devOnlyVersions: string[] = ['v15', 'v17', 'v19'];
 let worker;
 
 // Try validating node version


### PR DESCRIPTION
https://nodejs.org/en/blog/announcements/v19-release-announce/

As a reminder, odd-number releases never go LTS, meaning we will never support v19 in Azure and don't need dev ops testing or anything like that.