### PR TITLE
Add script file properties to function metadata

### DIFF
--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -50,6 +50,7 @@ export class WorkerChannel {
     functions: { [id: string]: RegisteredFunction } = {};
     workerIndexingLocked = false;
     isUsingWorkerIndexing = false;
+    currentEntryPoint?: string;
 
     constructor(workerId: string, eventStream: IEventStream, legacyFunctionLoader: ILegacyFunctionLoader) {
         this.workerId = workerId;

--- a/src/startApp.ts
+++ b/src/startApp.ts
@@ -55,7 +55,13 @@ async function loadEntryPointFile(functionAppDirectory: string, channel: WorkerC
                     level: LogLevel.Debug,
                     logCategory: LogCategory.System,
                 });
-                await loadScriptFile(path.join(functionAppDirectory, file), channel.packageJson);
+                try {
+                    const entryPointFilePath = path.join(functionAppDirectory, file);
+                    channel.currentEntryPoint = entryPointFilePath;
+                    await loadScriptFile(entryPointFilePath, channel.packageJson);
+                } finally {
+                    channel.currentEntryPoint = undefined;
+                }
                 channel.log({
                     message: `Loaded entry point file "${file}"`,
                     level: LogLevel.Debug,


### PR DESCRIPTION
I was spending some time comparing the python and node.js new programming model experiences. One difference I noticed was the "scriptFile" and "functionDirectory" settings for the function metadata. I theorize this information might be helpful for tooling like the portal, so I went ahead and added it. Unfortunately I did some testing and this change alone did not seem to affect the portal "Code + Test" experience. They must be doing something extra for Python, but regardless I still think these changes are a good idea

|Example Python|Old Node.js Behavior|New Node.js Behavior|
|---|---|---|
|<img width="367" alt="Screen Shot 2022-11-08 at 2 08 54 PM" src="https://user-images.githubusercontent.com/11282622/200686562-ff595496-c8da-41f6-8e77-fe27dfb92332.png">|<img width="367" alt="Screen Shot 2022-11-08 at 2 11 04 PM" src="https://user-images.githubusercontent.com/11282622/200686728-07c0132f-bf86-4da2-80f5-1aba39233dcf.png">|<img width="492" alt="Screen Shot 2022-11-08 at 2 09 02 PM" src="https://user-images.githubusercontent.com/11282622/200686595-fa70b931-2d7c-49bd-aa04-17d1a153cd7e.png">|





