### PR TITLE
Remove workerId from error logs

### DIFF
--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -57,9 +57,9 @@ export function startNodeWorker(args) {
         const error = ensureErrorType(err);
         let errorMessage: string;
         if (error.isAzureFunctionsSystemError) {
-            errorMessage = `Worker ${workerId} uncaught exception: ${error.stack || err}`;
+            errorMessage = `Worker uncaught exception: ${error.stack || err}`;
         } else {
-            errorMessage = `Worker ${workerId} uncaught exception (learn more: https://go.microsoft.com/fwlink/?linkid=2097909 ): ${
+            errorMessage = `Worker uncaught exception (learn more: https://go.microsoft.com/fwlink/?linkid=2097909 ): ${
                 error.stack || err
             }`;
         }

--- a/src/setupEventStream.ts
+++ b/src/setupEventStream.ts
@@ -28,7 +28,7 @@ export function setupEventStream(channel: WorkerChannel): void {
     });
 
     channel.eventStream.on('error', function (err) {
-        systemError(`Worker ${channel.workerId} encountered event stream error: `, err);
+        systemError(`Worker encountered event stream error: `, err);
         throw new AzFuncSystemError(err);
     });
 
@@ -37,7 +37,7 @@ export function setupEventStream(channel: WorkerChannel): void {
     channel.eventStream.write = function checkWrite(msg) {
         const msgError = rpc.StreamingMessage.verify(msg);
         if (msgError) {
-            systemError(`Worker ${channel.workerId} malformed message`, msgError);
+            systemError(`Worker malformed message`, msgError);
             throw new AzFuncSystemError(msgError);
         }
         oldWrite.apply(channel.eventStream, [msg]);
@@ -89,7 +89,7 @@ async function handleMessage(channel: WorkerChannel, inMsg: rpc.StreamingMessage
                 // Not yet implemented
                 return;
             default:
-                throw new AzFuncSystemError(`Worker ${channel.workerId} had no handler for message '${eventName}'`);
+                throw new AzFuncSystemError(`Worker had no handler for message '${eventName}'`);
         }
 
         request = nonNullProp(inMsg, eventName);

--- a/test/eventHandlers/FunctionEnvironmentReloadHandler.test.ts
+++ b/test/eventHandlers/FunctionEnvironmentReloadHandler.test.ts
@@ -35,7 +35,7 @@ export namespace Msg {
 
     export const noHandlerRpcLog: rpc.IStreamingMessage = {
         rpcLog: {
-            message: "Worker 00000000-0000-0000-0000-000000000000 had no handler for message 'undefined'",
+            message: "Worker had no handler for message 'undefined'",
             level: LogLevel.Error,
             logCategory: LogCategory.System,
         },


### PR DESCRIPTION
I've noticed a few situations when troubleshooting an app where it can be difficult to get the count of a specific error because we have the worker id in the message. You'll end up with something like this:

![Screenshot 2023-02-17 at 3 26 32 PM](https://user-images.githubusercontent.com/11282622/219816045-2d79b890-530f-40af-a2de-532dd35469d4.png)

The worker id is already tracked in the "Source" field in telemetry, so we don't really need it in the message.

I could've removed the workerId from debug and info logs, too, but I think they're fine as-is. You never really need to collate those messages like you would error logs.