### PR TITLE
Remove "v" from node version

### DIFF
--- a/src/eventHandlers/WorkerInitHandler.ts
+++ b/src/eventHandlers/WorkerInitHandler.ts
@@ -23,7 +23,7 @@ export class WorkerInitHandler extends EventHandler<'workerInitRequest', 'worker
         return {
             workerMetadata: {
                 runtimeName: 'node',
-                runtimeVersion: process.version,
+                runtimeVersion: process.versions.node,
                 workerBitness: process.arch,
                 workerVersion,
             },

--- a/test/eventHandlers/WorkerInitHandler.test.ts
+++ b/test/eventHandlers/WorkerInitHandler.test.ts
@@ -28,7 +28,7 @@ export namespace Msg {
     }
 
     const workerMetadataRegExps = {
-        'workerInitResponse.workerMetadata.runtimeVersion': /^v[0-9]+\.[0-9]+\.[0-9]+$/,
+        'workerInitResponse.workerMetadata.runtimeVersion': /^[0-9]+\.[0-9]+\.[0-9]+$/,
         'workerInitResponse.workerMetadata.workerBitness': /^(x64|ia32|arm64)$/,
         'workerInitResponse.workerMetadata.workerVersion': /^3\.[0-9]+\.[0-9]+$/,
     };


### PR DESCRIPTION
Related to https://github.com/Azure/azure-functions-nodejs-worker/issues/633

I was gonna implement logic to remove the "v" manually, but intellisense told me this:
<img width="659" alt="Screenshot 2023-02-17 at 3 39 36 PM" src="https://user-images.githubusercontent.com/11282622/219817556-8ac7f088-b6e4-4270-b25e-5ffeb88a2a6c.png">
