### PR TITLE
Preemptively unblock Node 20

### DIFF
--- a/azure-pipelines/e2e-integration-test.yml
+++ b/azure-pipelines/e2e-integration-test.yml
@@ -1,7 +1,8 @@
 variables: {
   NODE_14: '14.x',
   NODE_16: '16.x',
-  NODE_18: '18.x'
+  NODE_18: '18.x',
+  NODE_20: '19.x' # Temporarily using v19 until v20 is released
 }
 
 pr: none
@@ -19,6 +20,9 @@ strategy:
       UBUNTU_NODE18:
         IMAGE_TYPE: 'ubuntu-latest'
         NODE_VERSION: $(NODE_18)
+      UBUNTU_NODE20:
+        IMAGE_TYPE: 'ubuntu-latest'
+        NODE_VERSION: $(NODE_20)
       WINDOWS_NODE14:
         IMAGE_TYPE: 'windows-latest'
         NODE_VERSION: $(NODE_14)
@@ -28,6 +32,9 @@ strategy:
       WINDOWS_NODE18:
         IMAGE_TYPE: 'windows-latest'
         NODE_VERSION: $(NODE_18)
+      WINDOWS_NODE20:
+        IMAGE_TYPE: 'windows-latest'
+        NODE_VERSION: $(NODE_20)
       MAC_NODE14:
         IMAGE_TYPE: 'macOS-latest'
         NODE_VERSION: $(NODE_14)
@@ -37,6 +44,9 @@ strategy:
       MAC_NODE18:
         IMAGE_TYPE: 'macOS-latest'
         NODE_VERSION: $(NODE_18)
+      MAC_NODE20:
+        IMAGE_TYPE: 'macOS-latest'
+        NODE_VERSION: $(NODE_20)
 pool:
     vmImage: $(IMAGE_TYPE)
 steps:

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -1,7 +1,8 @@
 variables: {
   NODE_14: '14.x',
   NODE_16: '16.x',
-  NODE_18: '18.x'
+  NODE_18: '18.x',
+  NODE_20: '19.x' # Temporarily using v19 until v20 is released
 }
 
 pr:
@@ -25,6 +26,9 @@ jobs:
       UBUNTU_NODE18:
         IMAGE_TYPE: 'ubuntu-latest'
         NODE_VERSION: $(NODE_18)
+      UBUNTU_NODE20:
+        IMAGE_TYPE: 'ubuntu-latest'
+        NODE_VERSION: $(NODE_20)
       WINDOWS_NODE14:
         IMAGE_TYPE: 'windows-latest'
         NODE_VERSION: $(NODE_14)
@@ -34,6 +38,9 @@ jobs:
       WINDOWS_NODE18:
         IMAGE_TYPE: 'windows-latest'
         NODE_VERSION: $(NODE_18)
+      WINDOWS_NODE20:
+        IMAGE_TYPE: 'windows-latest'
+        NODE_VERSION: $(NODE_20)
       MAC_NODE14:
         IMAGE_TYPE: 'macOS-latest'
         NODE_VERSION: $(NODE_14)
@@ -43,6 +50,9 @@ jobs:
       MAC_NODE18:
         IMAGE_TYPE: 'macOS-latest'
         NODE_VERSION: $(NODE_18)
+      MAC_NODE20:
+        IMAGE_TYPE: 'macOS-latest'
+        NODE_VERSION: $(NODE_20)
   pool:
     vmImage: $(IMAGE_TYPE)
   steps:
@@ -80,6 +90,9 @@ jobs:
       UBUNTU_NODE18:
         IMAGE_TYPE: 'ubuntu-latest'
         NODE_VERSION: $(NODE_18)
+      UBUNTU_NODE20:
+        IMAGE_TYPE: 'ubuntu-latest'
+        NODE_VERSION: $(NODE_20)
       WINDOWS_NODE14:
         IMAGE_TYPE: 'windows-latest'
         NODE_VERSION: $(NODE_14)
@@ -89,6 +102,9 @@ jobs:
       WINDOWS_NODE18:
         IMAGE_TYPE: 'windows-latest'
         NODE_VERSION: $(NODE_18)
+      WINDOWS_NODE20:
+        IMAGE_TYPE: 'windows-latest'
+        NODE_VERSION: $(NODE_20)
       MAC_NODE14:
         IMAGE_TYPE: 'macOS-latest'
         NODE_VERSION: $(NODE_14)
@@ -98,6 +114,9 @@ jobs:
       MAC_NODE18:
         IMAGE_TYPE: 'macOS-latest'
         NODE_VERSION: $(NODE_18)
+      MAC_NODE20:
+        IMAGE_TYPE: 'macOS-latest'
+        NODE_VERSION: $(NODE_20)
   pool:
     vmImage: $(IMAGE_TYPE)
   steps:

--- a/src/nodejsWorker.ts
+++ b/src/nodejsWorker.ts
@@ -4,7 +4,7 @@
 const logPrefix = 'LanguageWorkerConsoleLog';
 const errorPrefix = logPrefix + '[error] ';
 const warnPrefix = logPrefix + '[warn] ';
-const supportedVersions: string[] = ['v14', 'v16', 'v18'];
+const supportedVersions: string[] = ['v14', 'v16', 'v18', 'v20'];
 const devOnlyVersions: string[] = ['v15', 'v17', 'v19'];
 let worker;
 

--- a/test/eventHandlers/WorkerInitHandler.test.ts
+++ b/test/eventHandlers/WorkerInitHandler.test.ts
@@ -6,6 +6,7 @@ import * as escapeStringRegexp from 'escape-string-regexp';
 import 'mocha';
 import { ITestCallbackContext } from 'mocha';
 import * as mockFs from 'mock-fs';
+import * as semver from 'semver';
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
 import { logColdStartWarning } from '../../src/eventHandlers/WorkerInitHandler';
 import { WorkerChannel } from '../../src/WorkerChannel';
@@ -218,6 +219,10 @@ describe('WorkerInitHandler', () => {
             },
         });
 
+        const jsonError = semver.gte(process.versions.node, '19.0.0')
+            ? 'Unexpected token \'g\', "gArB@g3 dAtA" is not valid JSON'
+            : 'Unexpected token g in JSON at position 0';
+
         stream.addTestMessage(Msg.init(appDir));
         await stream.assertCalledWith(
             Msg.receivedInitLog,
@@ -225,7 +230,7 @@ describe('WorkerInitHandler', () => {
                 `Worker failed to load package.json: file content is not valid JSON: ${path.join(
                     appDir,
                     'package.json'
-                )}: Unexpected token g in JSON at position 0`
+                )}: ${jsonError}`
             ),
             Msg.response
         );


### PR DESCRIPTION
The sooner the better!

v20 will be based off of v19, so I think it's good enough to use v19 for our CI testing for now

Related to https://github.com/Azure/azure-functions-nodejs-library/issues/170