### PR TITLE
Warn users with long load times

### DIFF
--- a/src/eventHandlers/FunctionLoadHandler.ts
+++ b/src/eventHandlers/FunctionLoadHandler.ts
@@ -34,7 +34,7 @@ export class FunctionLoadHandler extends EventHandler<'functionLoadRequest', 'fu
             const functionId = nonNullProp(msg, 'functionId');
             const metadata = nonNullProp(msg, 'metadata');
             try {
-                await channel.legacyFunctionLoader.load(functionId, metadata, channel.packageJson);
+                await channel.legacyFunctionLoader.load(channel, functionId, metadata, channel.packageJson);
             } catch (err) {
                 const error = ensureErrorType(err);
                 error.isAzureFunctionsSystemError = true;

--- a/src/loadScriptFile.ts
+++ b/src/loadScriptFile.ts
@@ -1,24 +1,56 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
+import * as path from 'path';
 import * as url from 'url';
+import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
 import { AzFuncSystemError } from './errors';
 import { PackageJson } from './parsers/parsePackageJson';
+import { WorkerChannel } from './WorkerChannel';
+import LogCategory = rpc.RpcLog.RpcLogCategory;
+import LogLevel = rpc.RpcLog.Level;
 
-export async function loadScriptFile(filePath: string, packageJson: PackageJson): Promise<unknown> {
-    let script: unknown;
-    if (isESModule(filePath, packageJson)) {
-        const fileUrl = url.pathToFileURL(filePath);
-        if (fileUrl.href) {
-            // use eval so it doesn't get compiled into a require()
-            script = await eval('import(fileUrl.href)');
+export async function loadScriptFile(
+    channel: WorkerChannel,
+    filePath: string,
+    packageJson: PackageJson
+): Promise<unknown> {
+    const start = Date.now();
+    try {
+        let script: unknown;
+        if (isESModule(filePath, packageJson)) {
+            const fileUrl = url.pathToFileURL(filePath);
+            if (fileUrl.href) {
+                // use eval so it doesn't get compiled into a require()
+                script = await eval('import(fileUrl.href)');
+            } else {
+                throw new AzFuncSystemError(`'${filePath}' could not be converted to file URL (${fileUrl.href})`);
+            }
         } else {
-            throw new AzFuncSystemError(`'${filePath}' could not be converted to file URL (${fileUrl.href})`);
+            script = require(/* webpackIgnore: true */ filePath);
         }
-    } else {
-        script = require(/* webpackIgnore: true */ filePath);
+        return script;
+    } finally {
+        warnIfLongLoadTime(channel, filePath, start);
     }
-    return script;
+}
+
+function warnIfLongLoadTime(channel: WorkerChannel, filePath: string, start: number): void {
+    const timeElapsed = Date.now() - start;
+    const rfpName = 'WEBSITE_RUN_FROM_PACKAGE';
+    const rfpValue = process.env[rfpName];
+    if (timeElapsed > 1000 && (rfpValue === undefined || rfpValue === '0')) {
+        channel.log({
+            message: `Loading "${path.basename(filePath)}" took ${timeElapsed}ms`,
+            level: LogLevel.Warning,
+            logCategory: LogCategory.System,
+        });
+        channel.log({
+            message: `Set "${rfpName}" to "1" to significantly improve load times. Learn more here: https://aka.ms/AAjon54`,
+            level: LogLevel.Warning,
+            logCategory: LogCategory.System,
+        });
+    }
 }
 
 export function isESModule(filePath: string, packageJson: PackageJson): boolean {

--- a/src/startApp.ts
+++ b/src/startApp.ts
@@ -58,7 +58,7 @@ async function loadEntryPointFile(functionAppDirectory: string, channel: WorkerC
                 try {
                     const entryPointFilePath = path.join(functionAppDirectory, file);
                     channel.currentEntryPoint = entryPointFilePath;
-                    await loadScriptFile(entryPointFilePath, channel.packageJson);
+                    await loadScriptFile(channel, entryPointFilePath, channel.packageJson);
                 } finally {
                     channel.currentEntryPoint = undefined;
                 }

--- a/test/LegacyFunctionLoader.test.ts
+++ b/test/LegacyFunctionLoader.test.ts
@@ -5,15 +5,18 @@ import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import 'mocha';
 import * as mock from 'mock-require';
+import * as sinon from 'sinon';
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
 import { LegacyFunctionLoader } from '../src/LegacyFunctionLoader';
 import { nonNullValue } from '../src/utils/nonNull';
+import { WorkerChannel } from '../src/WorkerChannel';
 const expect = chai.expect;
 chai.use(chaiAsPromised);
 
 describe('LegacyFunctionLoader', () => {
     let loader: LegacyFunctionLoader;
     let context, logs;
+    const channel: WorkerChannel = <WorkerChannel>(<any>sinon.createStubInstance(WorkerChannel));
 
     beforeEach(() => {
         loader = new LegacyFunctionLoader();
@@ -32,6 +35,7 @@ describe('LegacyFunctionLoader', () => {
         mock('test', {});
         await expect(
             loader.load(
+                channel,
                 'functionId',
                 <rpc.IRpcFunctionMetadata>{
                     scriptFile: 'test',
@@ -46,6 +50,7 @@ describe('LegacyFunctionLoader', () => {
     it('does not load proxy function', async () => {
         mock('test', {});
         await loader.load(
+            channel,
             'functionId',
             <rpc.IRpcFunctionMetadata>{
                 isProxy: true,
@@ -61,6 +66,7 @@ describe('LegacyFunctionLoader', () => {
         const entryPoint = 'wrongEntryPoint';
         await expect(
             loader.load(
+                channel,
                 'functionId',
                 <rpc.IRpcFunctionMetadata>{
                     scriptFile: 'test',
@@ -78,6 +84,7 @@ describe('LegacyFunctionLoader', () => {
         const entryPoint = 'test';
         await expect(
             loader.load(
+                channel,
                 'functionId',
                 <rpc.IRpcFunctionMetadata>{
                     scriptFile: 'test',
@@ -109,6 +116,7 @@ describe('LegacyFunctionLoader', () => {
         mock('test', new FuncObject());
 
         await loader.load(
+            channel,
             'functionId',
             <rpc.IRpcFunctionMetadata>{
                 scriptFile: 'test',
@@ -127,6 +135,7 @@ describe('LegacyFunctionLoader', () => {
         mock('test', { test: async () => {} });
 
         await loader.load(
+            channel,
             'functionId',
             <rpc.IRpcFunctionMetadata>{
                 scriptFile: 'test',
@@ -146,6 +155,7 @@ describe('LegacyFunctionLoader', () => {
         mock('test', { test: async () => {} });
 
         await loader.load(
+            channel,
             'functionId',
             <rpc.IRpcFunctionMetadata>{
                 scriptFile: 'test',

--- a/test/eventHandlers/FunctionLoadHandler.test.ts
+++ b/test/eventHandlers/FunctionLoadHandler.test.ts
@@ -6,6 +6,7 @@ import * as sinon from 'sinon';
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
 import { LegacyFunctionLoader } from '../../src/LegacyFunctionLoader';
 import { PackageJson } from '../../src/parsers/parsePackageJson';
+import { WorkerChannel } from '../../src/WorkerChannel';
 import { beforeEventHandlerSuite } from './beforeEventHandlerSuite';
 import { TestEventStream } from './TestEventStream';
 import LogCategory = rpc.RpcLog.RpcLogCategory;
@@ -58,7 +59,9 @@ describe('FunctionLoadHandler', () => {
 
         const originalLoader = loader.load;
         try {
-            loader.load = sinon.stub<[string, rpc.IRpcFunctionMetadata, PackageJson], Promise<void>>().throws(err);
+            loader.load = sinon
+                .stub<[WorkerChannel, string, rpc.IRpcFunctionMetadata, PackageJson], Promise<void>>()
+                .throws(err);
 
             stream.addTestMessage({
                 requestId: 'id',

--- a/test/eventHandlers/entryPointFiles/longLoad.js
+++ b/test/eventHandlers/entryPointFiles/longLoad.js
@@ -1,0 +1,2 @@
+const start = Date.now();
+while (Date.now() < start + 1001) {}


### PR DESCRIPTION
and tell them to use WEBSITE_RUN_FROM_PACKAGE

This is one of the most common problems I see on incidents. As an example, for one incident we decreased the load time from 96 seconds to 90 milliseconds after adding WEBSITE_RUN_FROM_PACKAGE.