### PR TITLE
Add programming model info to worker metadata

### DIFF
--- a/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
+++ b/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
@@ -32,7 +32,8 @@ message StreamingMessage {
     WorkerInitRequest worker_init_request = 17;
     // Worker responds after initializing with its capabilities & status
     WorkerInitResponse worker_init_response = 16;
-    
+
+    // MESSAGE NOT USED
     // Worker periodically sends empty heartbeat message to host
     WorkerHeartbeat worker_heartbeat = 15;
 
@@ -85,6 +86,13 @@ message StreamingMessage {
 
     // Host gets the list of function load responses
     FunctionLoadResponseCollection function_load_response_collection = 32;
+    
+    // Host sends required metadata to worker to warmup the worker
+    WorkerWarmupRequest worker_warmup_request = 33;
+    
+    // Worker responds after warming up with the warmup result
+    WorkerWarmupResponse worker_warmup_response = 34;
+    
   }
 }
 
@@ -120,7 +128,7 @@ message WorkerInitRequest {
 
 // Worker responds with the result of initializing itself
 message WorkerInitResponse {
-  // NOT USED
+  // PROPERTY NOT USED
   // TODO: Remove from protobuf during next breaking change release
   string worker_version = 1;
 
@@ -173,7 +181,7 @@ message StatusResult {
   repeated RpcLog logs = 3;
 }
 
-// NOT USED
+// MESSAGE NOT USED
 // TODO: Remove from protobuf during next breaking change release
 message WorkerHeartbeat {}
 
@@ -187,7 +195,7 @@ message WorkerTerminate {
 message FileChangeEventRequest {
   // Types of File change operations (See link for more info: https://msdn.microsoft.com/en-us/library/t6xf43e0(v=vs.110).aspx)
   enum Type {
-	  Unknown = 0;
+    Unknown = 0;
     Created = 1;
     Deleted = 2;
     Changed = 4;
@@ -237,6 +245,13 @@ message FunctionEnvironmentReloadRequest {
 }
 
 message FunctionEnvironmentReloadResponse {
+  // After specialization, worker sends capabilities & metadata.
+  // Worker metadata captured for telemetry purposes
+  WorkerMetadata worker_metadata = 1;
+
+  // A map of worker supported features/capabilities
+  map<string, string> capabilities = 2;
+
   // Status of the response
   StatusResult result = 3;
 }
@@ -325,7 +340,7 @@ message RpcFunctionMetadata {
   // Properties for function metadata
   // They're usually specific to a worker and largely passed along to the controller API for use
   // outside the host
-   map<string,string> Properties = 16;
+   map<string,string> properties = 16;
 }
 
 // Host tells worker it is ready to receive metadata
@@ -369,14 +384,14 @@ message InvocationRequest {
 
 // Host sends ActivityId, traceStateString and Tags from host
 message RpcTraceContext {
-	// This corresponds to Activity.Current?.Id
-	string trace_parent = 1;
+  // This corresponds to Activity.Current?.Id
+  string trace_parent = 1;
 
-	// This corresponds to Activity.Current?.TraceStateString
-	string trace_state = 2;
+  // This corresponds to Activity.Current?.TraceStateString
+  string trace_state = 2;
 
-	// This corresponds to Activity.Current?.Tags
-	map<string, string> attributes = 3;
+  // This corresponds to Activity.Current?.Tags
+  map<string, string> attributes = 3;
 }
 
 // Host sends retry context for a function invocation
@@ -396,8 +411,8 @@ message InvocationCancel {
   // Unique id for invocation
   string invocation_id = 2;
 
-  // Time period before force shutdown
-  google.protobuf.Duration grace_period = 1; // could also use absolute time
+  // PROPERTY NOT USED
+  google.protobuf.Duration grace_period = 1;
 }
 
 // Worker responds with status of Invocation
@@ -415,6 +430,15 @@ message InvocationResponse {
   StatusResult result = 3;
 }
 
+message WorkerWarmupRequest {
+  // Full path of worker.config.json location
+  string worker_directory = 1;
+}
+
+message WorkerWarmupResponse {
+  StatusResult result = 1;
+}
+
 // Used to encapsulate data which could be a variety of types
 message TypedData {
   oneof data {
@@ -429,6 +453,8 @@ message TypedData {
     CollectionString collection_string = 9;
     CollectionDouble collection_double = 10;
     CollectionSInt64 collection_sint64 = 11;
+    ModelBindingData model_binding_data = 12;
+    CollectionModelBindingData collection_model_binding_data = 13;
   }
 }
 
@@ -496,20 +522,20 @@ message ParameterBinding {
 
 // Used to describe a given binding on load
 message BindingInfo {
-    // Indicates whether it is an input or output binding (or a fancy inout binding)
-    enum Direction {
-      in = 0;
-      out = 1;
-      inout = 2;
-    }
+  // Indicates whether it is an input or output binding (or a fancy inout binding)
+  enum Direction {
+    in = 0;
+    out = 1;
+    inout = 2;
+  }
 
-    // Indicates the type of the data for the binding
-    enum DataType {
-      undefined = 0;
-      string = 1;
-      binary = 2;
-      stream = 3;
-    }
+  // Indicates the type of the data for the binding
+  enum DataType {
+    undefined = 0;
+    string = 1;
+    binary = 2;
+    stream = 3;
+  }
 
   // Type of binding (e.g. HttpTrigger)
   string type = 2;
@@ -518,6 +544,9 @@ message BindingInfo {
   Direction direction = 3;
 
   DataType data_type = 4;
+
+  // Properties for binding metadata
+  map<string, string> properties = 5;
 }
 
 // Used to send logs back to the Host
@@ -582,13 +611,13 @@ message RpcException {
   // Textual message describing the exception
   string message = 2;
 
-  // Worker specifies whether exception is a user exception, 
-  // for purpose of application insights logging. Defaults to false. 
+  // Worker specifies whether exception is a user exception,
+  // for purpose of application insights logging. Defaults to false.
   bool is_user_exception = 4;
 
   // Type of exception. If it's a user exception, the type is passed along to app insights.
   // Otherwise, it's ignored for now.
-  string type = 5; 
+  string type = 5;
 }
 
 // Http cookie type. Note that only name and value are used for Http requests
@@ -646,4 +675,26 @@ message RpcHttp {
   map<string,NullableString> nullable_headers = 20;
   map<string,NullableString> nullable_params = 21;
   map<string,NullableString> nullable_query = 22;
+}
+
+// Message representing Microsoft.Azure.WebJobs.ParameterBindingData
+// Used for hydrating SDK-type bindings in out-of-proc workers
+message ModelBindingData
+{
+    // The version of the binding data content
+    string version = 1;
+
+    // The extension source of the binding data
+    string source = 2;
+
+    // The content type of the binding data content
+    string content_type = 3;
+
+    // The binding data content
+    bytes content = 4;
+}
+
+// Used to encapsulate collection model_binding_data
+message CollectionModelBindingData {
+  repeated ModelBindingData model_binding_data = 1;
 }

--- a/src/eventHandlers/EventHandler.ts
+++ b/src/eventHandlers/EventHandler.ts
@@ -31,7 +31,7 @@ export abstract class EventHandler<
     /**
      * The default response with any properties unique to this request that should be set for both success & failure scenarios
      */
-    abstract getDefaultResponse(request: TRequest): TResponse;
+    abstract getDefaultResponse(channel: WorkerChannel, request: TRequest): TResponse;
 
     /**
      * Handles the event and returns the response

--- a/src/eventHandlers/FunctionLoadHandler.ts
+++ b/src/eventHandlers/FunctionLoadHandler.ts
@@ -15,14 +15,14 @@ import LogLevel = rpc.RpcLog.Level;
 export class FunctionLoadHandler extends EventHandler<'functionLoadRequest', 'functionLoadResponse'> {
     readonly responseName = 'functionLoadResponse';
 
-    getDefaultResponse(msg: rpc.IFunctionLoadRequest): rpc.IFunctionLoadResponse {
+    getDefaultResponse(_channel: WorkerChannel, msg: rpc.IFunctionLoadRequest): rpc.IFunctionLoadResponse {
         return { functionId: msg.functionId };
     }
 
     async handleEvent(channel: WorkerChannel, msg: rpc.IFunctionLoadRequest): Promise<rpc.IFunctionLoadResponse> {
         channel.workerIndexingLocked = true;
 
-        const response = this.getDefaultResponse(msg);
+        const response = this.getDefaultResponse(channel, msg);
 
         channel.log({
             message: `Worker ${channel.workerId} received FunctionLoadRequest`,

--- a/src/eventHandlers/FunctionsMetadataHandler.ts
+++ b/src/eventHandlers/FunctionsMetadataHandler.ts
@@ -10,7 +10,7 @@ import LogLevel = rpc.RpcLog.Level;
 export class FunctionsMetadataHandler extends EventHandler<'functionsMetadataRequest', 'functionMetadataResponse'> {
     readonly responseName = 'functionMetadataResponse';
 
-    getDefaultResponse(_msg: rpc.IFunctionsMetadataRequest): rpc.IFunctionMetadataResponse {
+    getDefaultResponse(_channel: WorkerChannel, _msg: rpc.IFunctionsMetadataRequest): rpc.IFunctionMetadataResponse {
         return {
             useDefaultMetadataIndexing: true,
         };
@@ -22,7 +22,7 @@ export class FunctionsMetadataHandler extends EventHandler<'functionsMetadataReq
     ): Promise<rpc.IFunctionMetadataResponse> {
         channel.workerIndexingLocked = true;
 
-        const response = this.getDefaultResponse(msg);
+        const response = this.getDefaultResponse(channel, msg);
 
         channel.log({
             message: `Worker ${channel.workerId} received FunctionsMetadataRequest`,

--- a/src/eventHandlers/InvocationHandler.ts
+++ b/src/eventHandlers/InvocationHandler.ts
@@ -29,7 +29,7 @@ import { EventHandler } from './EventHandler';
 export class InvocationHandler extends EventHandler<'invocationRequest', 'invocationResponse'> {
     readonly responseName = 'invocationResponse';
 
-    getDefaultResponse(msg: rpc.IInvocationRequest): rpc.IInvocationResponse {
+    getDefaultResponse(_channel: WorkerChannel, msg: rpc.IInvocationRequest): rpc.IInvocationResponse {
         return { invocationId: msg.invocationId };
     }
 

--- a/src/eventHandlers/getWorkerMetadata.ts
+++ b/src/eventHandlers/getWorkerMetadata.ts
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
+import { version as workerVersion } from '../constants';
+import { WorkerChannel } from '../WorkerChannel';
+
+export function getWorkerMetadata(channel: WorkerChannel): rpc.IWorkerMetadata {
+    const result: rpc.IWorkerMetadata = {
+        runtimeName: 'node',
+        runtimeVersion: process.versions.node,
+        workerBitness: process.arch,
+        workerVersion,
+    };
+    if (channel.programmingModel) {
+        result.customProperties = {
+            modelName: channel.programmingModel.name,
+            modelVersion: channel.programmingModel.version,
+        };
+    }
+    return result;
+}

--- a/src/setupEventStream.ts
+++ b/src/setupEventStream.ts
@@ -107,7 +107,7 @@ async function handleMessage(channel: WorkerChannel, inMsg: rpc.StreamingMessage
         }
 
         if (eventHandler && request) {
-            const response = eventHandler.getDefaultResponse(request);
+            const response = eventHandler.getDefaultResponse(channel, request);
             response.result = {
                 status: rpc.StatusResult.Status.Failure,
                 exception: {

--- a/test/eventHandlers/FunctionEnvironmentReloadHandler.test.ts
+++ b/test/eventHandlers/FunctionEnvironmentReloadHandler.test.ts
@@ -7,7 +7,7 @@ import * as mock from 'mock-fs';
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
 import { WorkerChannel } from '../../src/WorkerChannel';
 import { beforeEventHandlerSuite } from './beforeEventHandlerSuite';
-import { TestEventStream } from './TestEventStream';
+import { RegExpStreamingMessage, TestEventStream } from './TestEventStream';
 import { Msg as WorkerInitMsg } from './WorkerInitHandler.test';
 import path = require('path');
 import LogCategory = rpc.RpcLog.RpcLogCategory;
@@ -24,14 +24,30 @@ export namespace Msg {
         };
     }
 
-    export const reloadSuccess: rpc.IStreamingMessage = {
-        requestId: 'id',
-        functionEnvironmentReloadResponse: {
-            result: {
-                status: rpc.StatusResult.Status.Success,
+    const workerMetadataRegExps = {
+        'functionEnvironmentReloadResponse.workerMetadata.runtimeVersion': /^[0-9]+\.[0-9]+\.[0-9]+$/,
+        'functionEnvironmentReloadResponse.workerMetadata.workerBitness': /^(x64|ia32|arm64)$/,
+        'functionEnvironmentReloadResponse.workerMetadata.workerVersion': /^3\.[0-9]+\.[0-9]+$/,
+        'functionEnvironmentReloadResponse.workerMetadata.customProperties.modelVersion': /^3\.[0-9]+\.[0-9]+$/,
+    };
+
+    export const reloadSuccess = new RegExpStreamingMessage(
+        {
+            requestId: 'id',
+            functionEnvironmentReloadResponse: {
+                result: {
+                    status: rpc.StatusResult.Status.Success,
+                },
+                workerMetadata: {
+                    runtimeName: 'node',
+                    customProperties: {
+                        modelName: '@azure/functions',
+                    },
+                },
             },
         },
-    };
+        workerMetadataRegExps
+    );
 
     export const noHandlerRpcLog: rpc.IStreamingMessage = {
         rpcLog: {

--- a/test/eventHandlers/WorkerInitHandler.test.ts
+++ b/test/eventHandlers/WorkerInitHandler.test.ts
@@ -32,6 +32,7 @@ export namespace Msg {
         'workerInitResponse.workerMetadata.runtimeVersion': /^[0-9]+\.[0-9]+\.[0-9]+$/,
         'workerInitResponse.workerMetadata.workerBitness': /^(x64|ia32|arm64)$/,
         'workerInitResponse.workerMetadata.workerVersion': /^3\.[0-9]+\.[0-9]+$/,
+        'workerInitResponse.workerMetadata.customProperties.modelVersion': /^3\.[0-9]+\.[0-9]+$/,
     };
 
     export const response = new RegExpStreamingMessage(
@@ -53,6 +54,9 @@ export namespace Msg {
                 },
                 workerMetadata: {
                     runtimeName: 'node',
+                    customProperties: {
+                        modelName: '@azure/functions',
+                    },
                 },
             },
         },


### PR DESCRIPTION
And include worker metadata in reload response (This wasn't supported until recently, which is why I had to update the protobuf)