### PR TITLE
Fix registerFunction for placeholders when indexing is on by default

### DIFF
--- a/src/WorkerChannel.ts
+++ b/src/WorkerChannel.ts
@@ -59,6 +59,13 @@ export class WorkerChannel {
         this.packageJson = {};
     }
 
+    reset(): void {
+        // Ideally this resets all app-related data
+        // That worked is tracked by https://github.com/Azure/azure-functions-nodejs-worker/issues/670
+        this.workerIndexingLocked = false;
+        this.isUsingWorkerIndexing = false;
+    }
+
     /**
      * Captured logs or relevant details can use the logs property
      * @param requestId gRPC message request id

--- a/src/eventHandlers/FunctionEnvironmentReloadHandler.ts
+++ b/src/eventHandlers/FunctionEnvironmentReloadHandler.ts
@@ -31,6 +31,8 @@ export class FunctionEnvironmentReloadHandler extends EventHandler<
         channel: WorkerChannel,
         msg: rpc.IFunctionEnvironmentReloadRequest
     ): Promise<rpc.IFunctionEnvironmentReloadResponse> {
+        channel.reset();
+
         const response = this.getDefaultResponse(channel, msg);
 
         // Add environment variables from incoming

--- a/test/eventHandlers/entryPointFiles/registerFunction.js
+++ b/test/eventHandlers/entryPointFiles/registerFunction.js
@@ -1,0 +1,2 @@
+const func = require('@azure/functions-core');
+func.registerFunction({ name: 'testFunc', bindings: []}, () => {});


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-nodejs-worker/issues/669

I honestly spent more time on the test than the fix in `src`, but I feel it's important to have a test to repro an impactful bug like this. Here's proof that the test will fail without my fix in `src`:
<img width="1324" alt="Screenshot 2023-03-21 at 10 59 29 AM" src="https://user-images.githubusercontent.com/11282622/226703275-c8660e79-b6a4-44a7-9884-8ba351f76cf2.png">

Also, I wanted to keep this change scoped as small as possible to get it out asap and keep the risk minimal. I feel like there's more we could do here, but left that work for a separate issue: https://github.com/Azure/azure-functions-nodejs-worker/issues/670

