### PR TITLE
Specify the file name in loading entrypoint error

### DIFF
--- a/src/startApp.ts
+++ b/src/startApp.ts
@@ -43,6 +43,7 @@ export async function startApp(functionAppDirectory: string, channel: WorkerChan
 async function loadEntryPointFile(functionAppDirectory: string, channel: WorkerChannel): Promise<void> {
     const entryPointPattern = channel.packageJson.main;
     if (entryPointPattern) {
+        let currentFile: string | undefined = undefined;
         try {
             const files = await globby(entryPointPattern, { cwd: functionAppDirectory });
             if (files.length === 0) {
@@ -50,6 +51,7 @@ async function loadEntryPointFile(functionAppDirectory: string, channel: WorkerC
             }
 
             for (const file of files) {
+                currentFile = file;
                 channel.log({
                     message: `Loading entry point file "${file}"`,
                     level: LogLevel.Debug,
@@ -71,7 +73,9 @@ async function loadEntryPointFile(functionAppDirectory: string, channel: WorkerC
         } catch (err) {
             const error = ensureErrorType(err);
             channel.log({
-                message: `Worker was unable to load entry point "${entryPointPattern}": ${error.message}`,
+                message: `Worker was unable to load entry point "${currentFile ? currentFile : entryPointPattern}": ${
+                    error.message
+                }`,
                 level: LogLevel.Warning,
                 logCategory: LogCategory.System,
             });


### PR DESCRIPTION
If multiple entrypoint files are specified using a globby pattern, print out the name of the file that threw an error if failed to load an entrypoint file. Example:

**Before:**

![image](https://github.com/Azure/azure-functions-nodejs-worker/assets/31644556/2223cadf-253c-4777-b171-9173103b7c82)


**After:**

![image](https://github.com/Azure/azure-functions-nodejs-worker/assets/31644556/59f9b186-af5c-4257-aa26-378330fb9007)
