### PR TITLE
Use prerelease version suffix in all versions

### DIFF
--- a/Worker.nuspec
+++ b/Worker.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Microsoft.Azure.Functions.NodeJsWorker</id>
-    <version>3.6.2$prereleaseSuffix$</version>
+    <version>3.6.2</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -24,6 +24,9 @@ jobs:
     displayName: 'Install Node.js'
   - script: npm ci
     displayName: 'npm ci'
+  - script: npm run updateVersion -- --buildNumber $(Build.BuildNumber)
+    displayName: 'npm run updateVersion'
+    condition: and(succeeded(), eq(${{ parameters.IsPrerelease }}, true))
   - script: npm run build
     displayName: 'npm run build'
   - script: npm run webpack
@@ -57,8 +60,6 @@ jobs:
       packagesToPack: '$(Build.SourcesDirectory)/Worker.nuspec'
       packDestination: '$(Build.ArtifactStagingDirectory)/worker'
       basePath: '$(Build.ArtifactStagingDirectory)/worker'
-      ${{ if eq(parameters.IsPrerelease, true) }}:
-        buildProperties: 'prereleaseSuffix=-alpha.$(Build.BuildNumber)'
   - task: NuGetCommand@2
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/v3.x'), eq(variables['UPLOADPACKAGETOPRERELEASEFEED'], true))
     inputs:

--- a/scripts/updateVersion.ts
+++ b/scripts/updateVersion.ts
@@ -10,7 +10,7 @@ import * as semver from 'semver';
 const repoRoot = path.join(__dirname, '..');
 const packageJsonPath = path.join(repoRoot, 'package.json');
 const nuspecPath = path.join(repoRoot, 'Worker.nuspec');
-const nuspecVersionRegex = /<version>(.*)\$prereleaseSuffix\$<\/version>/i;
+const nuspecVersionRegex = /<version>(.*)<\/version>/i;
 const constantsPath = path.join(repoRoot, 'src', 'constants.ts');
 const constantsVersionRegex = /version = '(.*)'/i;
 
@@ -19,18 +19,21 @@ if (args.validate) {
     validateVersion();
 } else if (args.version) {
     updateVersion(args.version);
+} else if (args.buildNumber) {
+    const currentVersion = validateVersion();
+    updateVersion(`${currentVersion}-alpha.${args.buildNumber}`);
 } else {
     console.log(`This script can be used to either update the version of the worker or validate that the repo is in a valid state with regards to versioning.
 
 Example usage:
 
 npm run updateVersion -- --version 3.3.0
-
+npm run updateVersion -- --buildNumber 20230517.1
 npm run updateVersion -- --validate`);
     throw new Error('Invalid arguments');
 }
 
-function validateVersion() {
+function validateVersion(): string {
     const packageJson = readJSONSync(packageJsonPath);
     const packageJsonVersion = packageJson.version;
 
@@ -51,6 +54,7 @@ function validateVersion() {
         throw new Error(`Worker versions do not match.`);
     } else {
         console.log('Versions match! 🎉');
+        return packageJsonVersion;
     }
 }
 


### PR DESCRIPTION
Not just the nuget package version. In e2e tests, I want to be able to see which specific prerelease version of the worker is being tested, and for that I need all versions to have the build number.