### PR TITLE
Rename worker channel to worker context

### DIFF
--- a/src/LegacyFunctionLoader.ts
+++ b/src/LegacyFunctionLoader.ts
@@ -4,7 +4,7 @@
 import { FunctionCallback } from '@azure/functions-core';
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
 import { RegisteredFunction } from './AppContext';
-import { channel } from './WorkerChannel';
+import { worker } from './WorkerContext';
 import { AzFuncSystemError } from './errors';
 import { loadScriptFile } from './loadScriptFile';
 import { PackageJson } from './parsers/parsePackageJson';
@@ -21,11 +21,11 @@ export async function loadLegacyFunction(
     const script: any = await loadScriptFile(nonNullProp(metadata, 'scriptFile'), packageJson);
     const entryPoint = <string>(metadata && metadata.entryPoint);
     const [callback, thisArg] = getEntryPoint(script, entryPoint);
-    channel.app.legacyFunctions[functionId] = { metadata, callback, thisArg };
+    worker.app.legacyFunctions[functionId] = { metadata, callback, thisArg };
 }
 
 export function getLegacyFunction(functionId: string): RegisteredFunction | undefined {
-    const loadedFunction = channel.app.legacyFunctions[functionId];
+    const loadedFunction = worker.app.legacyFunctions[functionId];
     if (loadedFunction) {
         return {
             metadata: loadedFunction.metadata,

--- a/src/WorkerContext.ts
+++ b/src/WorkerContext.ts
@@ -7,7 +7,7 @@ import { AppContext } from './AppContext';
 import { IEventStream } from './GrpcClient';
 import { AzFuncSystemError } from './errors';
 
-export class WorkerChannel {
+class WorkerContext {
     app = new AppContext();
     defaultProgrammingModel?: ProgrammingModel;
 
@@ -16,20 +16,20 @@ export class WorkerChannel {
      */
     _hostVersion?: string;
 
-    #workerId?: string;
+    #id?: string;
     #eventStream?: IEventStream;
-    #notInitializedMsg = 'WorkerChannel has not been initialized yet.';
+    #notInitializedMsg = 'WorkerContext has not been initialized yet.';
 
-    get workerId(): string {
-        if (!this.#workerId) {
+    get id(): string {
+        if (!this.#id) {
             throw new AzFuncSystemError(this.#notInitializedMsg);
         } else {
-            return this.#workerId;
+            return this.#id;
         }
     }
 
-    set workerId(value: string) {
-        this.#workerId = value;
+    set id(value: string) {
+        this.#id = value;
     }
 
     get eventStream(): IEventStream {
@@ -69,4 +69,4 @@ export class WorkerChannel {
     }
 }
 
-export const channel: WorkerChannel = new WorkerChannel();
+export const worker = new WorkerContext();

--- a/src/coreApi/registerFunction.ts
+++ b/src/coreApi/registerFunction.ts
@@ -5,15 +5,15 @@ import { FunctionCallback, FunctionMetadata } from '@azure/functions-core';
 import * as path from 'path';
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
 import { Disposable } from '../Disposable';
-import { channel } from '../WorkerChannel';
+import { worker } from '../WorkerContext';
 import { AzFuncSystemError } from '../errors';
 import { fromCoreFunctionMetadata } from './converters/fromCoreFunctionMetadata';
 
 export function registerFunction(metadata: FunctionMetadata, callback: FunctionCallback): Disposable {
-    if (channel.app.workerIndexingLocked) {
+    if (worker.app.workerIndexingLocked) {
         throw new AzFuncSystemError('A function can only be registered during app startup.');
     }
-    channel.app.isUsingWorkerIndexing = true;
+    worker.app.isUsingWorkerIndexing = true;
 
     const functionId = metadata.functionId || metadata.name;
 
@@ -27,20 +27,20 @@ export function registerFunction(metadata: FunctionMetadata, callback: FunctionC
 
     // The host validates that the `scriptFile` property is defined. Neither the host nor the worker needs it, but tooling like the portal may use it so we'll make a best guess
     // (The real script file may be a separate file referenced from the entry point, or it may be coming from a different entry point entirely if there are some async shenanigans)
-    if (channel.app.currentEntryPoint) {
-        rpcMetadata.scriptFile = path.basename(channel.app.currentEntryPoint);
-        rpcMetadata.directory = path.dirname(channel.app.currentEntryPoint);
+    if (worker.app.currentEntryPoint) {
+        rpcMetadata.scriptFile = path.basename(worker.app.currentEntryPoint);
+        rpcMetadata.directory = path.dirname(worker.app.currentEntryPoint);
     } else {
         rpcMetadata.scriptFile = 'unknown';
     }
 
-    channel.app.functions[functionId] = { metadata: rpcMetadata, callback };
+    worker.app.functions[functionId] = { metadata: rpcMetadata, callback };
 
     return new Disposable(() => {
-        if (channel.app.workerIndexingLocked) {
+        if (worker.app.workerIndexingLocked) {
             throw new AzFuncSystemError('A function can only be disposed during app startup.');
         } else {
-            delete channel.app.functions[functionId];
+            delete worker.app.functions[functionId];
         }
     });
 }

--- a/src/coreApi/setProgrammingModel.ts
+++ b/src/coreApi/setProgrammingModel.ts
@@ -3,20 +3,20 @@
 
 import { ProgrammingModel } from '@azure/functions-core';
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
-import { channel } from '../WorkerChannel';
+import { worker } from '../WorkerContext';
 import LogCategory = rpc.RpcLog.RpcLogCategory;
 import LogLevel = rpc.RpcLog.Level;
 
 export function setProgrammingModel(programmingModel: ProgrammingModel): void {
     // Log when setting the programming model, except for the initial default one (partially because the grpc channels aren't fully setup at that time)
-    if (channel.app.programmingModel) {
-        channel.log({
+    if (worker.app.programmingModel) {
+        worker.log({
             message: `Setting Node.js programming model to "${programmingModel.name}" version "${programmingModel.version}"`,
             level: LogLevel.Information,
             logCategory: LogCategory.System,
         });
     } else {
-        channel.defaultProgrammingModel = programmingModel;
+        worker.defaultProgrammingModel = programmingModel;
     }
-    channel.app.programmingModel = programmingModel;
+    worker.app.programmingModel = programmingModel;
 }

--- a/src/eventHandlers/FunctionEnvironmentReloadHandler.ts
+++ b/src/eventHandlers/FunctionEnvironmentReloadHandler.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
-import { channel } from '../WorkerChannel';
+import { worker } from '../WorkerContext';
 import { startApp } from '../startApp';
 import { EventHandler } from './EventHandler';
 import { getWorkerMetadata } from './getWorkerMetadata';
@@ -25,13 +25,13 @@ export class FunctionEnvironmentReloadHandler extends EventHandler<
     }
 
     async handleEvent(msg: rpc.IFunctionEnvironmentReloadRequest): Promise<rpc.IFunctionEnvironmentReloadResponse> {
-        channel.resetApp();
+        worker.resetApp();
 
         const response = this.getDefaultResponse(msg);
 
         // Add environment variables from incoming
         const numVariables = (msg.environmentVariables && Object.keys(msg.environmentVariables).length) || 0;
-        channel.log({
+        worker.log({
             message: `Reloading environment variables. Found ${numVariables} variables to reload.`,
             level: LogLevel.Information,
             logCategory: LogCategory.System,
@@ -44,7 +44,7 @@ export class FunctionEnvironmentReloadHandler extends EventHandler<
 
         // Change current working directory
         if (msg.functionAppDirectory) {
-            channel.log({
+            worker.log({
                 message: `Changing current working directory to ${msg.functionAppDirectory}`,
                 level: LogLevel.Information,
                 logCategory: LogCategory.System,

--- a/src/eventHandlers/FunctionLoadHandler.ts
+++ b/src/eventHandlers/FunctionLoadHandler.ts
@@ -3,7 +3,7 @@
 
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
 import { loadLegacyFunction } from '../LegacyFunctionLoader';
-import { channel } from '../WorkerChannel';
+import { worker } from '../WorkerContext';
 import { ensureErrorType } from '../errors';
 import { nonNullProp } from '../utils/nonNull';
 import { EventHandler } from './EventHandler';
@@ -21,21 +21,21 @@ export class FunctionLoadHandler extends EventHandler<'functionLoadRequest', 'fu
     }
 
     async handleEvent(msg: rpc.IFunctionLoadRequest): Promise<rpc.IFunctionLoadResponse> {
-        channel.app.workerIndexingLocked = true;
+        worker.app.workerIndexingLocked = true;
 
         const response = this.getDefaultResponse(msg);
 
-        channel.log({
-            message: `Worker ${channel.workerId} received FunctionLoadRequest`,
+        worker.log({
+            message: `Worker ${worker.id} received FunctionLoadRequest`,
             level: LogLevel.Debug,
             logCategory: LogCategory.System,
         });
 
-        if (!channel.app.isUsingWorkerIndexing) {
+        if (!worker.app.isUsingWorkerIndexing) {
             const functionId = nonNullProp(msg, 'functionId');
             const metadata = nonNullProp(msg, 'metadata');
             try {
-                await loadLegacyFunction(functionId, metadata, channel.app.packageJson);
+                await loadLegacyFunction(functionId, metadata, worker.app.packageJson);
             } catch (err) {
                 const error = ensureErrorType(err);
                 error.isAzureFunctionsSystemError = true;

--- a/src/eventHandlers/FunctionsMetadataHandler.ts
+++ b/src/eventHandlers/FunctionsMetadataHandler.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
-import { channel } from '../WorkerChannel';
+import { worker } from '../WorkerContext';
 import { EventHandler } from './EventHandler';
 import LogCategory = rpc.RpcLog.RpcLogCategory;
 import LogLevel = rpc.RpcLog.Level;
@@ -17,17 +17,17 @@ export class FunctionsMetadataHandler extends EventHandler<'functionsMetadataReq
     }
 
     async handleEvent(msg: rpc.IFunctionsMetadataRequest): Promise<rpc.IFunctionMetadataResponse> {
-        channel.app.workerIndexingLocked = true;
+        worker.app.workerIndexingLocked = true;
 
         const response = this.getDefaultResponse(msg);
 
-        channel.log({
-            message: `Worker ${channel.workerId} received FunctionsMetadataRequest`,
+        worker.log({
+            message: `Worker ${worker.id} received FunctionsMetadataRequest`,
             level: LogLevel.Debug,
             logCategory: LogCategory.System,
         });
 
-        const functions = Object.values(channel.app.functions);
+        const functions = Object.values(worker.app.functions);
         if (functions.length > 0) {
             response.useDefaultMetadataIndexing = false;
             response.functionMetadataResults = functions.map((f) => f.metadata);

--- a/src/eventHandlers/WorkerInitHandler.ts
+++ b/src/eventHandlers/WorkerInitHandler.ts
@@ -4,7 +4,7 @@
 import { access, constants } from 'fs';
 import * as path from 'path';
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
-import { channel } from '../WorkerChannel';
+import { worker } from '../WorkerContext';
 import { isError } from '../errors';
 import { startApp } from '../startApp';
 import { nonNullProp } from '../utils/nonNull';
@@ -28,15 +28,15 @@ export class WorkerInitHandler extends EventHandler<'workerInitRequest', 'worker
     async handleEvent(msg: rpc.IWorkerInitRequest): Promise<rpc.IWorkerInitResponse> {
         const response = this.getDefaultResponse(msg);
 
-        channel.log({
-            message: `Worker ${channel.workerId} received WorkerInitRequest`,
+        worker.log({
+            message: `Worker ${worker.id} received WorkerInitRequest`,
             level: LogLevel.Debug,
             logCategory: LogCategory.System,
         });
 
         logColdStartWarning();
 
-        channel._hostVersion = nonNullProp(msg, 'hostVersion');
+        worker._hostVersion = nonNullProp(msg, 'hostVersion');
 
         if (msg.functionAppDirectory) {
             await startApp(msg.functionAppDirectory);
@@ -71,7 +71,7 @@ export function logColdStartWarning(delayInMs?: number): void {
         setTimeout(() => {
             access(path.join(scriptRoot, 'package.json'), constants.F_OK, (err) => {
                 if (isError(err)) {
-                    channel.log({
+                    worker.log({
                         message:
                             'package.json is not found at the root of the Function App in Azure Files - cold start for NodeJs can be affected.',
                         level: LogLevel.Debug,

--- a/src/eventHandlers/getWorkerMetadata.ts
+++ b/src/eventHandlers/getWorkerMetadata.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
-import { channel } from '../WorkerChannel';
+import { worker } from '../WorkerContext';
 import { version as workerVersion } from '../constants';
 
 export function getWorkerMetadata(): rpc.IWorkerMetadata {
@@ -13,10 +13,10 @@ export function getWorkerMetadata(): rpc.IWorkerMetadata {
         workerBitness: process.arch === 'ia32' ? 'x86' : process.arch,
         workerVersion,
     };
-    if (channel.app.programmingModel) {
+    if (worker.app.programmingModel) {
         result.customProperties = {
-            modelName: channel.app.programmingModel.name,
-            modelVersion: channel.app.programmingModel.version,
+            modelName: worker.app.programmingModel.name,
+            modelVersion: worker.app.programmingModel.version,
         };
     }
     return result;

--- a/src/eventHandlers/terminateWorker.ts
+++ b/src/eventHandlers/terminateWorker.ts
@@ -3,14 +3,14 @@
 
 import { AppTerminateContext } from '@azure/functions-core';
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
-import { channel } from '../WorkerChannel';
+import { worker } from '../WorkerContext';
 import { ReadOnlyError } from '../errors';
 import { executeHooks } from '../hooks/executeHooks';
 import LogCategory = rpc.RpcLog.RpcLogCategory;
 import LogLevel = rpc.RpcLog.Level;
 
 export async function terminateWorker(_msg: rpc.IWorkerTerminate) {
-    channel.log({
+    worker.log({
         message: 'Received workerTerminate message; gracefully shutting down worker',
         level: LogLevel.Debug,
         logCategory: LogCategory.System,
@@ -18,13 +18,13 @@ export async function terminateWorker(_msg: rpc.IWorkerTerminate) {
 
     const appTerminateContext: AppTerminateContext = {
         get hookData() {
-            return channel.app.appLevelOnlyHookData;
+            return worker.app.appLevelOnlyHookData;
         },
         set hookData(_obj) {
             throw new ReadOnlyError('hookData');
         },
         get appHookData() {
-            return channel.app.appHookData;
+            return worker.app.appHookData;
         },
         set appHookData(_obj) {
             throw new ReadOnlyError('appHookData');
@@ -33,6 +33,6 @@ export async function terminateWorker(_msg: rpc.IWorkerTerminate) {
 
     await executeHooks('appTerminate', appTerminateContext);
 
-    channel.eventStream.end();
+    worker.eventStream.end();
     process.exit(0);
 }

--- a/src/hooks/executeHooks.ts
+++ b/src/hooks/executeHooks.ts
@@ -3,7 +3,7 @@
 
 import { HookContext } from '@azure/functions-core';
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
-import { channel } from '../WorkerChannel';
+import { worker } from '../WorkerContext';
 import { getHooks } from './getHooks';
 import LogLevel = rpc.RpcLog.Level;
 import LogCategory = rpc.RpcLog.RpcLogCategory;
@@ -16,7 +16,7 @@ export async function executeHooks(
 ): Promise<void> {
     const callbacks = getHooks(hookName);
     if (callbacks.length > 0) {
-        channel.log({
+        worker.log({
             message: `Executing ${callbacks.length} "${hookName}" hooks`,
             level: LogLevel.Debug,
             logCategory: LogCategory.System,
@@ -26,7 +26,7 @@ export async function executeHooks(
         for (const callback of callbacks) {
             await callback(context);
         }
-        channel.log({
+        worker.log({
             message: `Executed "${hookName}" hooks`,
             level: LogLevel.Debug,
             logCategory: LogCategory.System,

--- a/src/hooks/getHooks.ts
+++ b/src/hooks/getHooks.ts
@@ -2,19 +2,19 @@
 // Licensed under the MIT License.
 
 import { HookCallback } from '@azure/functions-core';
-import { channel } from '../WorkerChannel';
+import { worker } from '../WorkerContext';
 import { AzFuncRangeError } from '../errors';
 
 export function getHooks(hookName: string): HookCallback[] {
     switch (hookName) {
         case 'preInvocation':
-            return channel.app.preInvocationHooks;
+            return worker.app.preInvocationHooks;
         case 'postInvocation':
-            return channel.app.postInvocationHooks;
+            return worker.app.postInvocationHooks;
         case 'appStart':
-            return channel.app.appStartHooks;
+            return worker.app.appStartHooks;
         case 'appTerminate':
-            return channel.app.appTerminateHooks;
+            return worker.app.appTerminateHooks;
         default:
             throw new AzFuncRangeError(`Unrecognized hook "${hookName}"`);
     }

--- a/src/loadScriptFile.ts
+++ b/src/loadScriptFile.ts
@@ -4,7 +4,7 @@
 import * as path from 'path';
 import * as url from 'url';
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
-import { channel } from './WorkerChannel';
+import { worker } from './WorkerContext';
 import { AzFuncSystemError } from './errors';
 import { PackageJson } from './parsers/parsePackageJson';
 import LogCategory = rpc.RpcLog.RpcLogCategory;
@@ -40,12 +40,12 @@ function warnIfLongLoadTime(filePath: string, start: number): void {
         (rfpValue === undefined || rfpValue === '0') &&
         process.env.AZURE_FUNCTIONS_ENVIRONMENT !== 'Development' // don't show in core tools
     ) {
-        channel.log({
+        worker.log({
             message: `Loading "${path.basename(filePath)}" took ${timeElapsed}ms`,
             level: LogLevel.Warning,
             logCategory: LogCategory.System,
         });
-        channel.log({
+        worker.log({
             message: `Set "${rfpName}" to "1" to significantly improve load times. Learn more here: https://aka.ms/AAjon54`,
             level: LogLevel.Warning,
             logCategory: LogCategory.System,

--- a/src/nodejsWorker.ts
+++ b/src/nodejsWorker.ts
@@ -6,7 +6,7 @@ const errorPrefix = logPrefix + '[error] ';
 const warnPrefix = logPrefix + '[warn] ';
 const supportedVersions: string[] = ['v14', 'v16', 'v18', 'v20'];
 const devOnlyVersions: string[] = ['v15', 'v17', 'v19'];
-let worker;
+let workerModule;
 
 // Try validating node version
 // NOTE: This method should be manually tested if changed as it is in a sensitive code path
@@ -55,11 +55,11 @@ validateNodeVersion(process.version);
 
 // Try requiring bundle
 try {
-    worker = require('./worker-bundle.js');
-    worker = worker.worker;
+    workerModule = require('./worker-bundle.js');
+    workerModule = workerModule.worker;
 } catch (err) {
     console.log(logPrefix + "Couldn't require bundle, falling back to Worker.js. " + err);
-    worker = require('./Worker.js');
+    workerModule = require('./Worker.js');
 }
 
-worker.startNodeWorker(process.argv);
+workerModule.startNodeWorker(process.argv);

--- a/src/setupCoreModule.ts
+++ b/src/setupCoreModule.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { Disposable } from './Disposable';
-import { channel } from './WorkerChannel';
+import { worker } from './WorkerContext';
 import { version } from './constants';
 import { registerFunction } from './coreApi/registerFunction';
 import { setProgrammingModel } from './coreApi/setProgrammingModel';
@@ -18,12 +18,12 @@ export function setupCoreModule(): void {
     const coreApi = {
         version: version,
         get hostVersion() {
-            return channel.hostVersion;
+            return worker.hostVersion;
         },
         registerHook,
         setProgrammingModel,
         getProgrammingModel: () => {
-            return channel.app.programmingModel;
+            return worker.app.programmingModel;
         },
         registerFunction,
         Disposable,

--- a/src/utils/blockedMonitor.ts
+++ b/src/utils/blockedMonitor.ts
@@ -7,12 +7,12 @@ import LogLevel = rpc.RpcLog.Level;
 import blockedAt = require('blocked-at');
 
 export function startBlockedMonitor(
-    channel: { log: (log: rpc.IRpcLog) => void },
+    worker: { log: (log: rpc.IRpcLog) => void },
     threshold = 500,
     intreval = 10000
 ): NodeJS.Timer {
     function logBlockedWarning(message: string) {
-        channel.log({
+        worker.log({
             message,
             level: LogLevel.Warning,
             logCategory: LogCategory.System,

--- a/test/eventHandlers/FunctionEnvironmentReloadHandler.test.ts
+++ b/test/eventHandlers/FunctionEnvironmentReloadHandler.test.ts
@@ -4,7 +4,7 @@
 import { expect } from 'chai';
 import * as fs from 'fs/promises';
 import 'mocha';
-import { channel } from '../../src/WorkerChannel';
+import { worker } from '../../src/WorkerContext';
 import { TestEventStream } from './TestEventStream';
 import { beforeEventHandlerSuite } from './beforeEventHandlerSuite';
 import { msg } from './msg';
@@ -170,7 +170,7 @@ describe('FunctionEnvironmentReloadHandler', () => {
             msg.envReload.changingCwdLog(testAppPath),
             msg.envReload.response
         );
-        expect(channel.app.packageJson).to.deep.equal(oldPackageJson);
+        expect(worker.app.packageJson).to.deep.equal(oldPackageJson);
 
         const newPackageJson = { type: 'commonjs', notHello: 'notWorld' };
         await fs.writeFile(testPackageJsonPath, JSON.stringify(newPackageJson));
@@ -185,7 +185,7 @@ describe('FunctionEnvironmentReloadHandler', () => {
             msg.envReload.changingCwdLog(testAppPath),
             msg.envReload.response
         );
-        expect(channel.app.packageJson).to.deep.equal(newPackageJson);
+        expect(worker.app.packageJson).to.deep.equal(newPackageJson);
     });
 
     it('loads package.json (placeholder scenario)', async () => {
@@ -193,7 +193,7 @@ describe('FunctionEnvironmentReloadHandler', () => {
         await fs.writeFile(testPackageJsonPath, JSON.stringify(packageJson));
 
         await mockPlaceholderInit();
-        expect(channel.app.packageJson).to.be.empty;
+        expect(worker.app.packageJson).to.be.empty;
 
         stream.addTestMessage({
             requestId: 'testReqId',
@@ -206,7 +206,7 @@ describe('FunctionEnvironmentReloadHandler', () => {
             msg.envReload.changingCwdLog(testAppPath),
             msg.envReload.response
         );
-        expect(channel.app.packageJson).to.deep.equal(packageJson);
+        expect(worker.app.packageJson).to.deep.equal(packageJson);
     });
 
     for (const extension of ['.js', '.mjs', '.cjs']) {

--- a/test/eventHandlers/FunctionLoadHandler.test.ts
+++ b/test/eventHandlers/FunctionLoadHandler.test.ts
@@ -4,7 +4,7 @@
 import { expect } from 'chai';
 import 'mocha';
 import { getLegacyFunction } from '../../src/LegacyFunctionLoader';
-import { channel } from '../../src/WorkerChannel';
+import { worker } from '../../src/WorkerContext';
 import { nonNullValue } from '../../src/utils/nonNull';
 import { TestEventStream } from './TestEventStream';
 import { beforeEventHandlerSuite } from './beforeEventHandlerSuite';
@@ -24,7 +24,7 @@ describe('FunctionLoadHandler', () => {
     it('responds to function load', async () => {
         stream.addTestMessage(msg.funcLoad.request('helloWorld.js'));
         await stream.assertCalledWith(msg.funcLoad.receivedRequestLog, msg.funcLoad.response);
-        expect(Object.keys(channel.app.legacyFunctions).length).to.equal(1);
+        expect(Object.keys(worker.app.legacyFunctions).length).to.equal(1);
     });
 
     it('handles function load exception', async () => {
@@ -70,7 +70,7 @@ describe('FunctionLoadHandler', () => {
 
         await stream.assertCalledWith(msg.funcLoad.receivedRequestLog, msg.funcLoad.response);
 
-        expect(Object.keys(channel.app.legacyFunctions).length).to.equal(0);
+        expect(Object.keys(worker.app.legacyFunctions).length).to.equal(0);
     });
 
     it('throws the resolved entry point is not a function', async () => {

--- a/test/eventHandlers/InvocationHandler.test.ts
+++ b/test/eventHandlers/InvocationHandler.test.ts
@@ -9,7 +9,7 @@ import { expect } from 'chai';
 import 'mocha';
 import * as sinon from 'sinon';
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
-import { channel } from '../../src/WorkerChannel';
+import { worker } from '../../src/WorkerContext';
 import { TestEventStream } from './TestEventStream';
 import { beforeEventHandlerSuite } from './beforeEventHandlerSuite';
 import { msg } from './msg';
@@ -258,7 +258,7 @@ describe('InvocationHandler', () => {
     }
 
     function registerV3Func(metadata: rpc.IRpcFunctionMetadata, callback: AzureFunction): void {
-        channel.app.legacyFunctions.testFuncId = {
+        worker.app.legacyFunctions.testFuncId = {
             metadata,
             callback: <coreTypes.FunctionCallback>callback,
             thisArg: undefined,

--- a/test/eventHandlers/TestEventStream.ts
+++ b/test/eventHandlers/TestEventStream.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import * as sinon from 'sinon';
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
 import { IEventStream } from '../../src/GrpcClient';
-import { channel } from '../../src/WorkerChannel';
+import { worker } from '../../src/WorkerContext';
 import { testAppSrcPath, testPackageJsonPath } from './testAppUtils';
 
 export class TestEventStream extends EventEmitter implements IEventStream {
@@ -97,8 +97,8 @@ export class TestEventStream extends EventEmitter implements IEventStream {
 
         await fs.writeFile(testPackageJsonPath, '{}');
 
-        channel._hostVersion = undefined;
-        channel.resetApp();
+        worker._hostVersion = undefined;
+        worker.resetApp();
 
         // minor delay so that it's more likely extraneous messages are associated with this test as opposed to leaking into the next test
         await new Promise((resolve) => setTimeout(resolve, 20));

--- a/test/eventHandlers/WorkerInitHandler.test.ts
+++ b/test/eventHandlers/WorkerInitHandler.test.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs/promises';
 import 'mocha';
 import { ITestCallbackContext } from 'mocha';
 import * as semver from 'semver';
-import { channel } from '../../src/WorkerChannel';
+import { worker } from '../../src/WorkerContext';
 import { logColdStartWarning } from '../../src/eventHandlers/WorkerInitHandler';
 import { TestEventStream } from './TestEventStream';
 import { beforeEventHandlerSuite } from './beforeEventHandlerSuite';
@@ -59,13 +59,13 @@ describe('WorkerInitHandler', () => {
 
         stream.addTestMessage(msg.init.request(testAppPath));
         await stream.assertCalledWith(msg.init.receivedRequestLog, msg.init.response);
-        expect(channel.app.packageJson).to.deep.equal(expectedPackageJson);
+        expect(worker.app.packageJson).to.deep.equal(expectedPackageJson);
     });
 
     it('loads empty package.json', async () => {
         stream.addTestMessage(msg.init.request('folderWithoutPackageJson'));
         await stream.assertCalledWith(msg.init.receivedRequestLog, msg.noPackageJsonWarning, msg.init.response);
-        expect(channel.app.packageJson).to.be.empty;
+        expect(worker.app.packageJson).to.be.empty;
     });
 
     it('ignores malformed package.json', async () => {
@@ -83,7 +83,7 @@ describe('WorkerInitHandler', () => {
             ),
             msg.init.response
         );
-        expect(channel.app.packageJson).to.be.empty;
+        expect(worker.app.packageJson).to.be.empty;
     });
 
     for (const extension of ['.js', '.mjs', '.cjs']) {

--- a/test/eventHandlers/beforeEventHandlerSuite.ts
+++ b/test/eventHandlers/beforeEventHandlerSuite.ts
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-import { channel } from '../../src/WorkerChannel';
+import { worker } from '../../src/WorkerContext';
 import { setupCoreModule } from '../../src/setupCoreModule';
 import { setupEventStream } from '../../src/setupEventStream';
 import { TestEventStream } from './TestEventStream';
@@ -10,9 +10,9 @@ let testEventStream: TestEventStream | undefined;
 
 export function beforeEventHandlerSuite() {
     if (!testEventStream) {
-        channel.workerId = '00000000-0000-0000-0000-000000000000';
+        worker.id = '00000000-0000-0000-0000-000000000000';
         testEventStream = new TestEventStream();
-        channel.eventStream = testEventStream;
+        worker.eventStream = testEventStream;
         setupEventStream();
         setupCoreModule();
         // Clear out logs that happened during setup, so that they don't affect whichever test runs first

--- a/test/eventHandlers/terminateWorker.test.ts
+++ b/test/eventHandlers/terminateWorker.test.ts
@@ -3,7 +3,7 @@
 
 import * as coreTypes from '@azure/functions-core';
 import { expect } from 'chai';
-import { channel } from '../../src/WorkerChannel';
+import { worker } from '../../src/WorkerContext';
 import { TestEventStream } from './TestEventStream';
 import { beforeEventHandlerSuite } from './beforeEventHandlerSuite';
 import { msg } from './msg';
@@ -18,7 +18,7 @@ describe('terminateWorker', () => {
     before(async () => {
         stream = beforeEventHandlerSuite();
         processExitStub = sinon.stub(process, 'exit');
-        streamEndStub = sinon.stub(channel.eventStream, 'end');
+        streamEndStub = sinon.stub(worker.eventStream, 'end');
         coreApi = await import('@azure/functions-core');
     });
 


### PR DESCRIPTION
No functional changes, just renaming.

I've been on a steady quest to destroy `WorkerChannel` since at least [Feb of 2022](https://github.com/Azure/azure-functions-nodejs-worker/pull/543), and with this PR I feel like I'm finally done! The new naming reflects its slimmed down nature and matches InvocationContext/HookContext/AppContext/etc.

![cry](https://gifdb.com/images/thumbnail/happy-crying-rachel-green-v23mjbkiaq3yv2w9.gif)