### PR TITLE
Throw error for duplicate function names in v4

### DIFF
--- a/src/coreApi/registerFunction.ts
+++ b/src/coreApi/registerFunction.ts
@@ -16,6 +16,9 @@ export function registerFunction(metadata: FunctionMetadata, callback: FunctionC
     channel.app.isUsingWorkerIndexing = true;
 
     const functionId = metadata.functionId || metadata.name;
+    if (functionId in channel.app.functions) {
+        throw new AzFuncSystemError(`A function with id "${functionId}" has already been registered.`);
+    }
 
     const rpcMetadata: rpc.IRpcFunctionMetadata = fromCoreFunctionMetadata(metadata);
     rpcMetadata.functionId = functionId;


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-nodejs-library/issues/62