### PR TITLE
Add invocation id to debug log

### DIFF
--- a/src/eventHandlers/InvocationHandler.ts
+++ b/src/eventHandlers/InvocationHandler.ts
@@ -59,7 +59,11 @@ export class InvocationHandler extends EventHandler<'invocationRequest', 'invoca
         );
 
         // Log invocation details to ensure the invocation received by node worker
-        coreCtx.log('debug', 'system', `Worker ${worker.id} received FunctionInvocationRequest`);
+        coreCtx.log(
+            'debug',
+            'system',
+            `Worker ${worker.id} received FunctionInvocationRequest for ${msg.invocationId}`
+        );
 
         const programmingModel: ProgrammingModel = nonNullProp(worker.app, 'programmingModel');
         const invocModel = programmingModel.getInvocationModel(coreCtx);

--- a/src/eventHandlers/InvocationHandler.ts
+++ b/src/eventHandlers/InvocationHandler.ts
@@ -62,7 +62,7 @@ export class InvocationHandler extends EventHandler<'invocationRequest', 'invoca
         coreCtx.log(
             'debug',
             'system',
-            `Worker ${worker.id} received FunctionInvocationRequest for ${msg.invocationId}`
+            `Worker ${worker.id} received FunctionInvocationRequest with invocationId ${msg.invocationId}`
         );
 
         const programmingModel: ProgrammingModel = nonNullProp(worker.app, 'programmingModel');

--- a/test/eventHandlers/msg.ts
+++ b/test/eventHandlers/msg.ts
@@ -353,7 +353,7 @@ export namespace msg {
         }
 
         export const receivedRequestLog = msg.invocation.debugLog(
-            'Worker 00000000-0000-0000-0000-000000000000 received FunctionInvocationRequest for 1'
+            'Worker 00000000-0000-0000-0000-000000000000 received FunctionInvocationRequest with invocationId 1'
         );
 
         export function executingHooksLog(count: number, hookName: string): TestMessage {

--- a/test/eventHandlers/msg.ts
+++ b/test/eventHandlers/msg.ts
@@ -353,7 +353,7 @@ export namespace msg {
         }
 
         export const receivedRequestLog = msg.invocation.debugLog(
-            'Worker 00000000-0000-0000-0000-000000000000 received FunctionInvocationRequest'
+            'Worker 00000000-0000-0000-0000-000000000000 received FunctionInvocationRequest for 1'
         );
 
         export function executingHooksLog(count: number, hookName: string): TestMessage {


### PR DESCRIPTION
I've had a few perf incidents recently where I thought this would be helpful in terms of isolating where the delay is coming from.