### PR TITLE
Minor fixes to be consistent with library repo hooks PR

### DIFF
--- a/src/Disposable.ts
+++ b/src/Disposable.ts
@@ -3,7 +3,7 @@
 
 /**
  * Based off of VS Code
- * https://github.com/microsoft/vscode/blob/a64e8e5673a44e5b9c2d493666bde684bd5a135c/src/vs/workbench/api/common/extHostTypes.ts#L32
+ * https://github.com/microsoft/vscode/blob/7bed4ce3e9f5059b5fc638c348f064edabcce5d2/src/vs/workbench/api/common/extHostTypes.ts#L65
  */
 export class Disposable {
     static from(...inDisposables: { dispose(): any }[]): Disposable {
@@ -27,7 +27,7 @@ export class Disposable {
     }
 
     dispose(): any {
-        if (this.#callOnDispose instanceof Function) {
+        if (typeof this.#callOnDispose === 'function') {
             this.#callOnDispose();
             this.#callOnDispose = undefined;
         }

--- a/types-core/index.d.ts
+++ b/types-core/index.d.ts
@@ -291,7 +291,7 @@ declare module '@azure/functions-core' {
         inputs: unknown[];
     }
 
-    type FunctionCallback = (context: unknown, ...inputs: unknown[]) => unknown;
+    type FunctionCallback = (...args: unknown[]) => unknown;
 
     // #region rpc types
     interface RpcFunctionMetadata {


### PR DESCRIPTION
Related to https://github.com/Azure/azure-functions-nodejs-library/pull/181

- Update latest Disposable source from VS Code
- Update `FunctionCallback` type to be more flexible