### PR TITLE
Check errors are writable

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -38,7 +38,7 @@ export function ensureErrorType(err: unknown): Error & Partial<AzFuncError> {
                 get() {
                     return readableMessage;
                 },
-                set(val) {
+                set(val: string) {
                     readableMessage = val;
                 },
             });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -31,9 +31,9 @@ export function ensureErrorType(err: unknown): Error & Partial<AzFuncError> {
     if (err instanceof Error) {
         if (Object.getOwnPropertyDescriptor(err, 'message')?.writable) {
             return err;
+        } else {
+            return new Error(JSON.stringify(err));
         }
-
-        return new Error(JSON.stringify(err));
     } else {
         let message: string;
         if (err === undefined || err === null) {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -30,19 +30,20 @@ export class ReadOnlyError extends AzFuncTypeError {
 export function ensureErrorType(err: unknown): Error & Partial<AzFuncError> {
     if (err instanceof Error) {
         const writable = Object.getOwnPropertyDescriptor(err, 'message')?.writable;
-        if (writable) {
-            return err;
-        } else {
-            // If we cannot modify the message, we want to wrap the original error
+        if (!writable) {
             // The motivation for this branch can be found in the below issue:
             // https://github.com/Azure/azure-functions-nodejs-library/issues/205
-            const oldStack = err.stack;
-            const oldName = err.name;
-            const newError = new Error(err.message);
-            newError.stack = oldStack;
-            newError.name = oldName;
-            return newError;
+            let readableMessage = err.message;
+            Object.defineProperty(err, 'message', {
+                get() {
+                    return readableMessage;
+                },
+                set(val) {
+                    readableMessage = val;
+                },
+            });
         }
+        return err;
     } else {
         let message: string;
         if (err === undefined || err === null) {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -28,9 +28,12 @@ export class ReadOnlyError extends AzFuncTypeError {
 }
 
 export function ensureErrorType(err: unknown): Error & Partial<AzFuncError> {
-    const writable = Object.getOwnPropertyDescriptor(err, 'message')?.writable;
-    if (err instanceof Error && writable) {
-        return err;
+    if (err instanceof Error) {
+        if (Object.getOwnPropertyDescriptor(err, 'message')?.writable) {
+            return err;
+        }
+
+        return new Error(JSON.stringify(err));
     } else {
         let message: string;
         if (err === undefined || err === null) {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -33,9 +33,12 @@ export function ensureErrorType(err: unknown): Error & Partial<AzFuncError> {
         if (writable) {
             return err;
         } else {
+            // If we cannot modify the message, we want to wrap the original error
+            // The motivation for this branch can be found in the below issue:
+            // https://github.com/Azure/azure-functions-nodejs-library/issues/205
             const oldStack = err.stack;
             const oldName = err.name;
-            const newError = 'message' in err ? new Error(err.message) : new Error(JSON.stringify(err));
+            const newError = new Error(err.message);
             newError.stack = oldStack;
             newError.name = oldName;
             return newError;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -29,7 +29,8 @@ export class ReadOnlyError extends AzFuncTypeError {
 
 export function ensureErrorType(err: unknown): Error & Partial<AzFuncError> {
     if (err instanceof Error) {
-        if (Object.getOwnPropertyDescriptor(err, 'message')?.writable) {
+        const writable = Object.getOwnPropertyDescriptor(err, 'message')?.writable;
+        if (writable) {
             return err;
         } else {
             return new Error(JSON.stringify(err));

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -28,7 +28,8 @@ export class ReadOnlyError extends AzFuncTypeError {
 }
 
 export function ensureErrorType(err: unknown): Error & Partial<AzFuncError> {
-    if (err instanceof Error) {
+    const writable = Object.getOwnPropertyDescriptor(err, 'message')?.writable;
+    if (err instanceof Error && writable) {
         return err;
     } else {
         let message: string;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -33,7 +33,12 @@ export function ensureErrorType(err: unknown): Error & Partial<AzFuncError> {
         if (writable) {
             return err;
         } else {
-            return new Error(JSON.stringify(err));
+            const oldStack = err.stack;
+            const oldName = err.name;
+            const newError = 'message' in err ? new Error(err.message) : new Error(JSON.stringify(err));
+            newError.stack = oldStack;
+            newError.name = oldName;
+            return newError;
         }
     } else {
         let message: string;

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -43,11 +43,18 @@ describe('errors', () => {
     });
 
     it('readonly error', () => {
-        const actualError = new Error('readonly');
+        class ReadOnlyError extends Error {
+            public readonly message = 'a readonly message';
+        }
+
+        const actualError = new ReadOnlyError();
         Object.defineProperty(actualError, 'message', { writable: false });
-        // JSON.stringify only includes enumerable properties, so we should expect an empty object
-        validateError(ensureErrorType(actualError), '{}');
-    })
+        // @ts-expect-error
+        const attemptToChangeMessage = () => actualError.message = 'exception';
+
+        expect(attemptToChangeMessage).to.throw();
+        validateError(ensureErrorType(actualError), '{"message":"a readonly message"}');
+    });
 
     function validateError(actual: Error, expectedMessage: string): void {
         expect(actual).to.be.instanceof(Error);

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -42,7 +42,7 @@ describe('errors', () => {
         expect(ensureErrorType(actualError)).to.equal(actualError);
     });
 
-    it('readonly error', () => {
+    it.only('readonly error', () => {
         class ReadOnlyError extends Error {
             get message(): string {
                 return 'a readonly message';
@@ -50,15 +50,15 @@ describe('errors', () => {
         }
 
         const actualError = new ReadOnlyError();
-        const oldStack = actualError.stack;
+
         // @ts-expect-error: create a function to test that writing throws an exception
         expect(() => (actualError.message = 'exception')).to.throw();
 
         const wrappedError = ensureErrorType(actualError);
-        wrappedError.message = `Readonly error can now have modified message: ${wrappedError.message}`;
+        wrappedError.message = 'Readonly error has been modified';
 
-        expect(wrappedError.message).to.equal('Readonly error can now have modified message: a readonly message');
-        expect(wrappedError.stack).to.equal(oldStack);
+        expect(wrappedError.message).to.equal('Readonly error has been modified');
+        expect(wrappedError.stack).to.contain('Readonly error has been modified');
     });
 
     function validateError(actual: Error, expectedMessage: string): void {

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -42,7 +42,7 @@ describe('errors', () => {
         expect(ensureErrorType(actualError)).to.equal(actualError);
     });
 
-    it.only('readonly error', () => {
+    it('readonly error', () => {
         class ReadOnlyError extends Error {
             get message(): string {
                 return 'a readonly message';

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -44,13 +44,13 @@ describe('errors', () => {
 
     it('readonly error', () => {
         class ReadOnlyError extends Error {
-            public readonly message = 'a readonly message';
+            readonly message = 'a readonly message';
         }
 
         const actualError = new ReadOnlyError();
         Object.defineProperty(actualError, 'message', { writable: false });
-        // @ts-expect-error
-        const attemptToChangeMessage = () => actualError.message = 'exception';
+        // @ts-expect-error: create a function to test that writing throws an exception
+        const attemptToChangeMessage = () => (actualError.message = 'exception');
 
         expect(attemptToChangeMessage).to.throw();
         validateError(ensureErrorType(actualError), '{"message":"a readonly message"}');

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -42,6 +42,13 @@ describe('errors', () => {
         expect(ensureErrorType(actualError)).to.equal(actualError);
     });
 
+    it('readonly error', () => {
+        const actualError = new Error('readonly');
+        Object.defineProperty(actualError, 'message', { writable: false });
+        // JSON.stringify only includes enumerable properties, so we should expect an empty object
+        validateError(ensureErrorType(actualError), '{}');
+    })
+
     function validateError(actual: Error, expectedMessage: string): void {
         expect(actual).to.be.instanceof(Error);
         expect(actual.message).to.equal(expectedMessage);


### PR DESCRIPTION
This PR addresses an issue raised in the Library repo: https://github.com/Azure/azure-functions-nodejs-library/issues/205.

In short, a customer was using a package that extends the `Error` class and renders the `message` property read-only.

This caused an error in `FunctionLoadHandler.ts` when we attempt to write our own custom error message:
```
error.message = `Worker was unable to load function ${metadata.name}: '${error.message}'`;

```
Our function `ensureErrorType` was not filtering out these read-only errors because  `instanceof Error` was in fact true. Therefore, we simply returned these errors without any modification, assuming they were in fact instances of `Error`, not a subclass with different behavior.

This PR introduces an explicit check to ensure that we are not passing along read-only objects and hitting this exception:
```
Exception: Cannot set property message of [object Object] which has only a getter
```