### PR TITLE
Create setErrorMessage function

### DIFF
--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as parseArgs from 'minimist';
-import { AzFuncSystemError, ensureErrorType } from './errors';
+import { AzFuncSystemError, ensureErrorType, setErrorMessage } from './errors';
 import { CreateGrpcEventStream } from './GrpcClient';
 import { setupCoreModule } from './setupCoreModule';
 import { setupEventStream } from './setupEventStream';
@@ -40,8 +40,9 @@ export function startNodeWorker(args) {
     } catch (err) {
         const error = ensureErrorType(err);
         error.isAzureFunctionsSystemError = true;
-        error.message = 'Error creating GRPC event stream: ' + error.message;
-        throw error;
+        const message = 'Error creating GRPC event stream: ' + error.message;
+        const modifiedError = setErrorMessage(error, message);
+        throw modifiedError;
     }
 
     setupEventStream();

--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as parseArgs from 'minimist';
-import { AzFuncSystemError, ensureErrorType, setErrorMessage } from './errors';
+import { AzFuncSystemError, ensureErrorType, trySetErrorMessage } from './errors';
 import { CreateGrpcEventStream } from './GrpcClient';
 import { setupCoreModule } from './setupCoreModule';
 import { setupEventStream } from './setupEventStream';
@@ -41,8 +41,8 @@ export function startNodeWorker(args) {
         const error = ensureErrorType(err);
         error.isAzureFunctionsSystemError = true;
         const message = 'Error creating GRPC event stream: ' + error.message;
-        const modifiedError = setErrorMessage(error, message);
-        throw modifiedError;
+        trySetErrorMessage(error, message);
+        throw error;
     }
 
     setupEventStream();

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -29,20 +29,6 @@ export class ReadOnlyError extends AzFuncTypeError {
 
 export function ensureErrorType(err: unknown): Error & Partial<AzFuncError> {
     if (err instanceof Error) {
-        const writable = Object.getOwnPropertyDescriptor(err, 'message')?.writable;
-        if (!writable) {
-            // The motivation for this branch can be found in the below issue:
-            // https://github.com/Azure/azure-functions-nodejs-library/issues/205
-            let readableMessage = err.message;
-            Object.defineProperty(err, 'message', {
-                get() {
-                    return readableMessage;
-                },
-                set(val: string) {
-                    readableMessage = val;
-                },
-            });
-        }
         return err;
     } else {
         let message: string;
@@ -56,6 +42,16 @@ export function ensureErrorType(err: unknown): Error & Partial<AzFuncError> {
             message = String(err);
         }
         return new Error(message);
+    }
+}
+
+export function setErrorMessage(err: Error, message: string): Error & Partial<AzFuncError> {
+    try {
+        err.message = message;
+        return err;
+    } catch {
+        // Return original error if we can't set the message
+        return err;
     }
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -9,6 +9,13 @@ export interface AzFuncError {
     isAzureFunctionsSystemError: boolean;
 }
 
+export interface TodoError extends Error, Partial<AzFuncError> {
+    /**
+     * Use `trySetErrorMessage` to set the error message
+     */
+    readonly message: string;
+}
+
 export class AzFuncSystemError extends Error {
     isAzureFunctionsSystemError = true;
 }
@@ -27,7 +34,7 @@ export class ReadOnlyError extends AzFuncTypeError {
     }
 }
 
-export function ensureErrorType(err: unknown): Error & Partial<AzFuncError> {
+export function ensureErrorType(err: unknown): TodoError {
     if (err instanceof Error) {
         return err;
     } else {
@@ -45,17 +52,11 @@ export function ensureErrorType(err: unknown): Error & Partial<AzFuncError> {
     }
 }
 
-export function setErrorMessage(err: Error, message: string): Error & Partial<AzFuncError> {
+export function trySetErrorMessage(err: Error, message: string): void {
     try {
         err.message = message;
-        return err;
-    } catch (e) {
-        if (e instanceof TypeError) {
-            // Return original error if we can't set the message
-            return err;
-        } else {
-            throw e;
-        }
+    } catch {
+        // If we can't set the message, we'll keep the error as is
     }
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -9,7 +9,7 @@ export interface AzFuncError {
     isAzureFunctionsSystemError: boolean;
 }
 
-export interface TodoError extends Error, Partial<AzFuncError> {
+export interface ValidatedError extends Error, Partial<AzFuncError> {
     /**
      * Use `trySetErrorMessage` to set the error message
      */
@@ -34,7 +34,7 @@ export class ReadOnlyError extends AzFuncTypeError {
     }
 }
 
-export function ensureErrorType(err: unknown): TodoError {
+export function ensureErrorType(err: unknown): ValidatedError {
     if (err instanceof Error) {
         return err;
     } else {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -49,9 +49,13 @@ export function setErrorMessage(err: Error, message: string): Error & Partial<Az
     try {
         err.message = message;
         return err;
-    } catch {
-        // Return original error if we can't set the message
-        return err;
+    } catch (e) {
+        if (e instanceof TypeError) {
+            // Return original error if we can't set the message
+            return err;
+        } else {
+            throw e;
+        }
     }
 }
 

--- a/src/eventHandlers/FunctionLoadHandler.ts
+++ b/src/eventHandlers/FunctionLoadHandler.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
-import { ensureErrorType } from '../errors';
+import { ensureErrorType, setErrorMessage } from '../errors';
 import { loadLegacyFunction } from '../LegacyFunctionLoader';
 import { isDefined, nonNullProp } from '../utils/nonNull';
 import { worker } from '../WorkerContext';
@@ -43,8 +43,9 @@ export class FunctionLoadHandler extends EventHandler<'functionLoadRequest', 'fu
             } catch (err) {
                 const error = ensureErrorType(err);
                 error.isAzureFunctionsSystemError = true;
-                error.message = `Worker was unable to load function ${metadata.name}: '${error.message}'`;
-                throw error;
+                const message = `Worker was unable to load function ${metadata.name}: '${error.message}'`;
+                const modifiedError = setErrorMessage(error, message);
+                throw modifiedError;
             }
         }
 

--- a/src/eventHandlers/FunctionLoadHandler.ts
+++ b/src/eventHandlers/FunctionLoadHandler.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { AzureFunctionsRpcMessages as rpc } from '../../azure-functions-language-worker-protobuf/src/rpc';
-import { ensureErrorType, setErrorMessage } from '../errors';
+import { ensureErrorType, trySetErrorMessage } from '../errors';
 import { loadLegacyFunction } from '../LegacyFunctionLoader';
 import { isDefined, nonNullProp } from '../utils/nonNull';
 import { worker } from '../WorkerContext';
@@ -44,8 +44,8 @@ export class FunctionLoadHandler extends EventHandler<'functionLoadRequest', 'fu
                 const error = ensureErrorType(err);
                 error.isAzureFunctionsSystemError = true;
                 const message = `Worker was unable to load function ${metadata.name}: '${error.message}'`;
-                const modifiedError = setErrorMessage(error, message);
-                throw modifiedError;
+                trySetErrorMessage(error, message);
+                throw error;
             }
         }
 

--- a/src/parsers/parsePackageJson.ts
+++ b/src/parsers/parsePackageJson.ts
@@ -3,7 +3,7 @@
 
 import { pathExists, readJson } from 'fs-extra';
 import * as path from 'path';
-import { AzFuncSystemError, ensureErrorType, setErrorMessage } from '../errors';
+import { AzFuncSystemError, ensureErrorType, trySetErrorMessage } from '../errors';
 
 export interface PackageJson {
     type?: string;
@@ -37,8 +37,8 @@ export async function parsePackageJson(dir: string): Promise<PackageJson> {
         const error: Error = ensureErrorType(err);
         if (error.name === 'SyntaxError') {
             const message = `file content is not valid JSON: ${error.message}`;
-            const modifiedError = setErrorMessage(error, message);
-            throw modifiedError;
+            trySetErrorMessage(error, message);
+            throw error;
         }
         throw error;
     }

--- a/src/parsers/parsePackageJson.ts
+++ b/src/parsers/parsePackageJson.ts
@@ -3,7 +3,7 @@
 
 import { pathExists, readJson } from 'fs-extra';
 import * as path from 'path';
-import { AzFuncSystemError, ensureErrorType } from '../errors';
+import { AzFuncSystemError, ensureErrorType, setErrorMessage } from '../errors';
 
 export interface PackageJson {
     type?: string;
@@ -36,7 +36,9 @@ export async function parsePackageJson(dir: string): Promise<PackageJson> {
     } catch (err) {
         const error: Error = ensureErrorType(err);
         if (error.name === 'SyntaxError') {
-            error.message = `file content is not valid JSON: ${error.message}`;
+            const message = `file content is not valid JSON: ${error.message}`;
+            const modifiedError = setErrorMessage(error, message);
+            throw modifiedError;
         }
         throw error;
     }

--- a/src/parsers/parsePackageJson.ts
+++ b/src/parsers/parsePackageJson.ts
@@ -38,7 +38,6 @@ export async function parsePackageJson(dir: string): Promise<PackageJson> {
         if (error.name === 'SyntaxError') {
             const message = `file content is not valid JSON: ${error.message}`;
             trySetErrorMessage(error, message);
-            throw error;
         }
         throw error;
     }

--- a/src/startApp.ts
+++ b/src/startApp.ts
@@ -3,7 +3,7 @@
 
 import { AppStartContext } from '@azure/functions-core';
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
-import { AzFuncSystemError, ensureErrorType, ReadOnlyError, setErrorMessage } from './errors';
+import { AzFuncSystemError, ensureErrorType, ReadOnlyError, trySetErrorMessage } from './errors';
 import { executeHooks } from './hooks/executeHooks';
 import { loadScriptFile } from './loadScriptFile';
 import { parsePackageJson } from './parsers/parsePackageJson';
@@ -104,13 +104,13 @@ async function loadEntryPointFile(functionAppDirectory: string): Promise<void> {
             }`;
 
             if (shouldBlockOnEntryPointError()) {
-                const modifiedError = setErrorMessage(error, newMessage);
-                modifiedError.isAzureFunctionsSystemError = true;
+                trySetErrorMessage(error, newMessage);
+                error.isAzureFunctionsSystemError = true;
                 // We don't want to throw this error now (during workerInit or funcEnvReload) because technically the worker is fine
                 // Instead, it will be thrown during functionMetadata or functionLoad response which better indicates that the user's app is the problem
-                worker.app.blockingAppStartError = modifiedError;
+                worker.app.blockingAppStartError = error;
                 // This will ensure the error makes it to the user's app insights
-                console.error(modifiedError.stack);
+                console.error(error.stack);
             } else {
                 // In this case, the error will never block the app
                 // The most we can do without breaking backwards compatibility is log it as a system log

--- a/src/startApp.ts
+++ b/src/startApp.ts
@@ -3,7 +3,7 @@
 
 import { AppStartContext } from '@azure/functions-core';
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
-import { AzFuncSystemError, ensureErrorType, ReadOnlyError } from './errors';
+import { AzFuncSystemError, ensureErrorType, ReadOnlyError, setErrorMessage } from './errors';
 import { executeHooks } from './hooks/executeHooks';
 import { loadScriptFile } from './loadScriptFile';
 import { parsePackageJson } from './parsers/parsePackageJson';
@@ -104,13 +104,13 @@ async function loadEntryPointFile(functionAppDirectory: string): Promise<void> {
             }`;
 
             if (shouldBlockOnEntryPointError()) {
-                error.message = newMessage;
-                error.isAzureFunctionsSystemError = true;
+                const modifiedError = setErrorMessage(error, newMessage);
+                modifiedError.isAzureFunctionsSystemError = true;
                 // We don't want to throw this error now (during workerInit or funcEnvReload) because technically the worker is fine
                 // Instead, it will be thrown during functionMetadata or functionLoad response which better indicates that the user's app is the problem
-                worker.app.blockingAppStartError = error;
+                worker.app.blockingAppStartError = modifiedError;
                 // This will ensure the error makes it to the user's app insights
-                console.error(error.stack);
+                console.error(modifiedError.stack);
             } else {
                 // In this case, the error will never block the app
                 // The most we can do without breaking backwards compatibility is log it as a system log

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -3,7 +3,7 @@
 
 import 'mocha';
 import { expect } from 'chai';
-import { ensureErrorType } from '../src/errors';
+import { ensureErrorType, setErrorMessage } from '../src/errors';
 
 describe('errors', () => {
     it('null', () => {
@@ -42,6 +42,13 @@ describe('errors', () => {
         expect(ensureErrorType(actualError)).to.equal(actualError);
     });
 
+    it('modify error message', () => {
+        const actualError = new Error('test2');
+        const modifiedError = setErrorMessage(actualError, 'modified message');
+
+        expect(modifiedError.message).to.equal('modified message');
+    });
+
     it('readonly error', () => {
         class ReadOnlyError extends Error {
             get message(): string {
@@ -55,10 +62,11 @@ describe('errors', () => {
         expect(() => (actualError.message = 'exception')).to.throw();
 
         const wrappedError = ensureErrorType(actualError);
-        wrappedError.message = 'Readonly error has been modified';
+        const message = 'Readonly error has not been modified';
+        const modifiedError = setErrorMessage(wrappedError, message);
 
-        expect(wrappedError.message).to.equal('Readonly error has been modified');
-        expect(wrappedError.stack).to.contain('Readonly error has been modified');
+        expect(modifiedError.message).to.equal('a readonly message');
+        expect(modifiedError.stack).to.not.contain('Readonly error has been modified');
     });
 
     function validateError(actual: Error, expectedMessage: string): void {

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -3,7 +3,7 @@
 
 import 'mocha';
 import { expect } from 'chai';
-import { ensureErrorType, setErrorMessage } from '../src/errors';
+import { ensureErrorType, trySetErrorMessage } from '../src/errors';
 
 describe('errors', () => {
     it('null', () => {
@@ -44,9 +44,9 @@ describe('errors', () => {
 
     it('modify error message', () => {
         const actualError = new Error('test2');
-        const modifiedError = setErrorMessage(actualError, 'modified message');
+        trySetErrorMessage(actualError, 'modified message');
 
-        expect(modifiedError.message).to.equal('modified message');
+        expect(actualError.message).to.equal('modified message');
     });
 
     it('readonly error', () => {
@@ -63,10 +63,10 @@ describe('errors', () => {
 
         const wrappedError = ensureErrorType(actualError);
         const message = 'Readonly error has not been modified';
-        const modifiedError = setErrorMessage(wrappedError, message);
+        trySetErrorMessage(wrappedError, message);
 
-        expect(modifiedError.message).to.equal('a readonly message');
-        expect(modifiedError.stack).to.not.contain('Readonly error has been modified');
+        expect(wrappedError.message).to.equal('a readonly message');
+        expect(wrappedError.stack).to.not.contain('Readonly error has been modified');
     });
 
     function validateError(actual: Error, expectedMessage: string): void {


### PR DESCRIPTION
This PR is a fix for [Exception: Cannot set property message of [object Object] which has only a getter](https://github.com/Azure/azure-functions-nodejs-library/issues/205).

In February, we merged an earlier fix for this same issue (#732).

However, @ryanbecker reported a problem with our initial approach.

Therefore, we have rolled back those changes and instead take a simpler approach. Everywhere we previously tried to write to `error.message`, we now catch any exceptions thrown by read-only errors. In those cases, we simply return the original error and do not attempt to modify its error message. 