### PR TITLE
Fix startup error not showing up in kusto

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -8,7 +8,7 @@ export interface AzFuncError {
      */
     isAzureFunctionsSystemError: boolean;
 
-    alreadyLoggedOverRpc?: boolean;
+    loggedOverRpc?: boolean;
 }
 
 export interface ValidatedError extends Error, Partial<AzFuncError> {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -7,6 +7,8 @@ export interface AzFuncError {
      * User errors cannot be tracked in our telemetry because they could have user information (users can still track it themselves in their app insights resource)
      */
     isAzureFunctionsSystemError: boolean;
+
+    alreadyLoggedOverRpc?: boolean;
 }
 
 export interface ValidatedError extends Error, Partial<AzFuncError> {

--- a/src/setupEventStream.ts
+++ b/src/setupEventStream.ts
@@ -98,7 +98,7 @@ async function handleMessage(inMsg: rpc.StreamingMessage): Promise<void> {
         outMsg[eventHandler.responseName] = response;
     } catch (err) {
         const error = ensureErrorType(err);
-        if (error.isAzureFunctionsSystemError && !error.alreadyLoggedOverRpc) {
+        if (error.isAzureFunctionsSystemError && !error.loggedOverRpc) {
             worker.log({
                 message: error.message,
                 level: LogLevel.Error,

--- a/src/setupEventStream.ts
+++ b/src/setupEventStream.ts
@@ -98,7 +98,7 @@ async function handleMessage(inMsg: rpc.StreamingMessage): Promise<void> {
         outMsg[eventHandler.responseName] = response;
     } catch (err) {
         const error = ensureErrorType(err);
-        if (error.isAzureFunctionsSystemError) {
+        if (error.isAzureFunctionsSystemError && !error.alreadyLoggedOverRpc) {
             worker.log({
                 message: error.message,
                 level: LogLevel.Error,

--- a/src/startApp.ts
+++ b/src/startApp.ts
@@ -113,13 +113,16 @@ async function loadEntryPointFile(functionAppDirectory: string): Promise<void> {
                 console.error(error.stack);
             } else {
                 // In this case, the error will never block the app
-                // The most we can do without breaking backwards compatibility is log it as a system log
-                worker.log({
-                    message: newMessage,
-                    level: LogLevel.Error,
-                    logCategory: LogCategory.System,
-                });
+                // The most we can do without breaking backwards compatibility is log it as an rpc system log below
             }
+
+            // Always log as rpc system log, which goes to our internal telemetry
+            worker.log({
+                message: newMessage,
+                level: LogLevel.Error,
+                logCategory: LogCategory.System,
+            });
+            error.alreadyLoggedOverRpc = true;
         }
     }
 }

--- a/src/startApp.ts
+++ b/src/startApp.ts
@@ -122,7 +122,7 @@ async function loadEntryPointFile(functionAppDirectory: string): Promise<void> {
                 level: LogLevel.Error,
                 logCategory: LogCategory.System,
             });
-            error.alreadyLoggedOverRpc = true;
+            error.loggedOverRpc = true;
         }
     }
 }

--- a/test/startApp.test.ts
+++ b/test/startApp.test.ts
@@ -53,11 +53,12 @@ describe('startApp', () => {
 
         stream.addTestMessage(msg.init.request(testAppPath));
         if (fileSubpath.includes('missing')) {
-            await stream.assertCalledWith(msg.init.receivedRequestLog, msg.init.response);
+            await stream.assertCalledWith(msg.init.receivedRequestLog, msg.errorLog(errorMessage), msg.init.response);
         } else {
             await stream.assertCalledWith(
                 msg.init.receivedRequestLog,
                 msg.loadingEntryPoint(fileSubpath),
+                msg.errorLog(errorMessage),
                 msg.init.response
             );
         }
@@ -66,7 +67,6 @@ describe('startApp', () => {
         if (isModelV4) {
             await stream.assertCalledWith(
                 msg.indexing.receivedRequestLog,
-                msg.errorLog(errorMessage),
                 msg.indexing.failedResponse(errorMessage, false)
             );
         } else {
@@ -74,11 +74,7 @@ describe('startApp', () => {
         }
 
         stream.addTestMessage(msg.funcLoad.request('helloWorld.js'));
-        await stream.assertCalledWith(
-            msg.funcLoad.receivedRequestLog,
-            msg.errorLog(errorMessage),
-            msg.funcLoad.failedResponse(errorMessage)
-        );
+        await stream.assertCalledWith(msg.funcLoad.receivedRequestLog, msg.funcLoad.failedResponse(errorMessage));
     }
 
     describe('Node >=v20', () => {


### PR DESCRIPTION
Found this bug a couple weeks ago when Thiago was debugging a bad node v4 app on flex.

## Repro steps

1. Create a v4 app
2. Use Node 20
3. Delete the http trigger code and add `throw new Error('test');` instead
4. Run your app
5. Wait a while then check app insights & kusto

## Expected

The error shows up in customer's app insights and our kusto

## Actual

The error only shows up in customer's app insights, but not kusto

## More info

Today, we save app startup errors that happen during workerInitRequest and return them during functionsMetadataRequest or functionLoadRequest instead (which also logs them - which is what I care about for this PR). However, if the error happens for a v4 app before the v4 model is registered in user code, we skip sending the error during functionsMetadataRequest because we think it's a v3 app and the host never sends a functionLoadRequest which only applies to v3 apps.

My fix is to always log the error right away and set a flag to prevent it from potentially being duplicated later.