### PR TITLE
Add logging to detect if function app dir doesn't change

### DIFF
--- a/src/AppContext.ts
+++ b/src/AppContext.ts
@@ -15,6 +15,10 @@ export interface LegacyRegisteredFunction extends RegisteredFunction {
 }
 
 export class AppContext {
+    functionAppDirectory: string | null | undefined;
+    constructor(functionAppDirectory: string | null | undefined) {
+        this.functionAppDirectory = functionAppDirectory;
+    }
     packageJson: PackageJson = {};
     /**
      * this hook data will be passed to (and set by) all hooks in all scopes

--- a/src/WorkerContext.ts
+++ b/src/WorkerContext.ts
@@ -10,7 +10,7 @@ import { IEventStream } from './GrpcClient';
 import { InvocationLogContext, LogHookContext } from './hooks/LogHookContext';
 
 class WorkerContext {
-    app = new AppContext();
+    app = new AppContext(undefined);
     defaultProgrammingModel?: ProgrammingModel;
 
     /**
@@ -54,8 +54,8 @@ class WorkerContext {
         }
     }
 
-    resetApp(): void {
-        this.app = new AppContext();
+    resetApp(functionAppDirectory: string | null | undefined): void {
+        this.app = new AppContext(functionAppDirectory);
         this.app.programmingModel = this.defaultProgrammingModel;
     }
 

--- a/src/eventHandlers/WorkerInitHandler.ts
+++ b/src/eventHandlers/WorkerInitHandler.ts
@@ -27,6 +27,15 @@ export class WorkerInitHandler extends EventHandler<'workerInitRequest', 'worker
     }
 
     async handleEvent(msg: rpc.IWorkerInitRequest): Promise<rpc.IWorkerInitResponse> {
+        if (!msg.functionAppDirectory) {
+            worker.log({
+                message: `WorkerInit functionAppDirectory is not defined`,
+                level: LogLevel.Debug,
+                logCategory: LogCategory.System,
+            });
+        }
+        worker.app.functionAppDirectory = msg.functionAppDirectory;
+
         const response = this.getDefaultResponse(msg);
 
         worker.log({

--- a/test/eventHandlers/FunctionEnvironmentReloadHandler.test.ts
+++ b/test/eventHandlers/FunctionEnvironmentReloadHandler.test.ts
@@ -38,7 +38,11 @@ describe('FunctionEnvironmentReloadHandler', () => {
                 functionAppDirectory: null,
             },
         });
-        await stream.assertCalledWith(msg.envReload.reloadEnvVarsLog(2), msg.envReload.response);
+        await stream.assertCalledWith(
+            msg.envReload.funcAppDirNotDefined,
+            msg.envReload.reloadEnvVarsLog(2),
+            msg.envReload.response
+        );
         expect(process.env.hello).to.equal('world');
         expect(process.env.SystemDrive).to.equal('Q:');
         expect(process.env.PlaceholderVariable).to.be.undefined;
@@ -56,7 +60,11 @@ describe('FunctionEnvironmentReloadHandler', () => {
                 functionAppDirectory: null,
             },
         });
-        await stream.assertCalledWith(msg.envReload.reloadEnvVarsLog(2), msg.envReload.response);
+        await stream.assertCalledWith(
+            msg.envReload.funcAppDirNotDefined,
+            msg.envReload.reloadEnvVarsLog(2),
+            msg.envReload.response
+        );
         expect(process.env.hello).to.equal('world');
         expect(process.env.SystemDrive).to.equal('Q:');
         expect(process.env.PlaceholderVariable).to.be.undefined;
@@ -80,7 +88,11 @@ describe('FunctionEnvironmentReloadHandler', () => {
                 functionAppDirectory: null,
             },
         });
-        await stream.assertCalledWith(msg.envReload.reloadEnvVarsLog(0), msg.envReload.response);
+        await stream.assertCalledWith(
+            msg.envReload.funcAppDirNotDefined,
+            msg.envReload.reloadEnvVarsLog(0),
+            msg.envReload.response
+        );
         expect(process.env).to.be.empty;
     });
 
@@ -92,7 +104,11 @@ describe('FunctionEnvironmentReloadHandler', () => {
                 functionAppDirectory: null,
             },
         });
-        await stream.assertCalledWith(msg.envReload.reloadEnvVarsLog(0), msg.envReload.response);
+        await stream.assertCalledWith(
+            msg.envReload.funcAppDirNotDefined,
+            msg.envReload.reloadEnvVarsLog(0),
+            msg.envReload.response
+        );
 
         stream.addTestMessage({
             requestId: 'testReqId',
@@ -108,7 +124,11 @@ describe('FunctionEnvironmentReloadHandler', () => {
                 functionAppDirectory: null,
             },
         });
-        await stream.assertCalledWith(msg.envReload.reloadEnvVarsLog(0), msg.envReload.response);
+        await stream.assertCalledWith(
+            msg.envReload.funcAppDirNotDefined,
+            msg.envReload.reloadEnvVarsLog(0),
+            msg.envReload.response
+        );
     });
 
     it('reloads environment variable and keeps cwd without functionAppDirectory', async () => {
@@ -123,7 +143,11 @@ describe('FunctionEnvironmentReloadHandler', () => {
                 functionAppDirectory: null,
             },
         });
-        await stream.assertCalledWith(msg.envReload.reloadEnvVarsLog(2), msg.envReload.response);
+        await stream.assertCalledWith(
+            msg.envReload.funcAppDirNotDefined,
+            msg.envReload.reloadEnvVarsLog(2),
+            msg.envReload.response
+        );
         expect(process.env.hello).to.equal('world');
         expect(process.env.SystemDrive).to.equal('Q:');
         expect(process.cwd() == cwd);
@@ -181,6 +205,7 @@ describe('FunctionEnvironmentReloadHandler', () => {
             },
         });
         await stream.assertCalledWith(
+            msg.envReload.funcAppDirNotChanged,
             msg.envReload.reloadEnvVarsLog(0),
             msg.envReload.changingCwdLog(testAppPath),
             msg.envReload.response

--- a/test/eventHandlers/TestEventStream.ts
+++ b/test/eventHandlers/TestEventStream.ts
@@ -102,7 +102,7 @@ export class TestEventStream extends EventEmitter implements IEventStream {
         await fs.writeFile(testPackageJsonPath, '{}');
 
         worker._hostVersion = undefined;
-        worker.resetApp();
+        worker.resetApp(this.originalCwd);
 
         // minor delay so that it's more likely extraneous messages are associated with this test as opposed to leaking into the next test
         await new Promise((resolve) => setTimeout(resolve, 20));

--- a/test/eventHandlers/msg.ts
+++ b/test/eventHandlers/msg.ts
@@ -193,6 +193,14 @@ export namespace msg {
             return msg.infoLog(`Changing current working directory to ${dir}`);
         }
 
+        export const funcAppDirNotDefined = msg.debugLog(
+            'FunctionEnvironmentReload functionAppDirectory is not defined'
+        );
+
+        export const funcAppDirNotChanged = msg.debugLog(
+            'FunctionEnvironmentReload functionAppDirectory has not changed'
+        );
+
         export const response = new RegExpStreamingMessage(
             {
                 requestId: 'testReqId',


### PR DESCRIPTION
Related to https://github.com/Azure/azure-functions-nodejs-worker/issues/737

My plan to fix that bug is to skip environment reload if we detect the functionAppDirectory is the same during workerInit and functionEnvironmentReload. However, I want to validate a few assumptions first:
1. I assume functionAppDirectory is always defined in both workerInit and functionEnvironmentReload
2. I assume the only time the directories are the same is the edge case mentioned in the bug above

The bug itself is rare, and IMO it would be a big deal if we skip environment reload for apps that still needed it - so that's why I'd rather be careful and add logs before actually making the change.