### PR TITLE
Migrating the NuGet Publishing Pipeline to 1ES

### DIFF
--- a/azure-pipelines/templates/worker.yml
+++ b/azure-pipelines/templates/worker.yml
@@ -1,5 +1,5 @@
 jobs:
-    - job: CreateWorkerRelease12
+    - job: CreateWorkerRelease
       displayName: 'Publish NodeJs Worker to Nuget'
       templateContext:
           outputParentDirectory: $(Build.ArtifactStagingDirectory)

--- a/azure-pipelines/templates/worker.yml
+++ b/azure-pipelines/templates/worker.yml
@@ -1,17 +1,18 @@
 jobs:
-- job: CreateWorkerRelease12
-  displayName: 'Publish NodeJs Worker to Nuget'
-  templateContext:
-    outputParentDirectory: $(Build.ArtifactStagingDirectory)
-    outputs:
-      - output: nuget
-        packagesToPush: '$(Build.ArtifactStagingDirectory)/dropOutput/*.nupkg'
-        publishVstsFeed: 'e6a70c92-4128-439f-8012-382fe78d6396/eb652719-f36a-4e78-8541-e13a3cd655f9'
-        nuGetFeedType: internal
-        allowPackageConflicts: true
-  steps:
-  - task: NuGetToolInstaller@1
-    displayName: 'Use NuGet 5x'
-    inputs:
-      versionSpec: 5.x
-      checkLatest: true
+    - job: CreateWorkerRelease12
+      displayName: 'Publish NodeJs Worker to Nuget'
+      templateContext:
+          outputParentDirectory: $(Build.ArtifactStagingDirectory)
+          outputs:
+              - output: nuget
+                condition: and(succeeded(), ${{ eq(parameters.IsPrerelease, true) }})
+                packagesToPush: '$(Build.ArtifactStagingDirectory)/dropOutput/*.nupkg'
+                publishVstsFeed: 'e6a70c92-4128-439f-8012-382fe78d6396/eb652719-f36a-4e78-8541-e13a3cd655f9'
+                nuGetFeedType: internal
+                allowPackageConflicts: true
+      steps:
+          - task: NuGetToolInstaller@1
+            displayName: 'Use NuGet 5x'
+            inputs:
+                versionSpec: 5.x
+                checkLatest: true

--- a/azure-pipelines/templates/worker.yml
+++ b/azure-pipelines/templates/worker.yml
@@ -1,0 +1,17 @@
+jobs:
+- job: CreateWorkerRelease12
+  displayName: 'Publish NodeJs Worker to Nuget'
+  templateContext:
+    outputParentDirectory: $(Build.ArtifactStagingDirectory)
+    outputs:
+      - output: nuget
+        packagesToPush: '$(Build.ArtifactStagingDirectory)/dropOutput/*.nupkg'
+        publishVstsFeed: 'e6a70c92-4128-439f-8012-382fe78d6396/eb652719-f36a-4e78-8541-e13a3cd655f9'
+        nuGetFeedType: internal
+        allowPackageConflicts: true
+  steps:
+  - task: NuGetToolInstaller@1
+    displayName: 'Use NuGet 5x'
+    inputs:
+      versionSpec: 5.x
+      checkLatest: true

--- a/azure-pipelines/worker-build.yml
+++ b/azure-pipelines/worker-build.yml
@@ -1,0 +1,53 @@
+parameters:
+  - name: IsPrerelease
+    type: boolean
+    default: true
+
+trigger:
+  batch: true
+  branches:
+    include:
+      - v3.x
+
+pr: none
+
+resources:
+    repositories:
+        - repository: 1es
+          type: git
+          name: 1ESPipelineTemplates/1ESPipelineTemplates
+          ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1es
+  parameters:
+    pool:
+      name: 1es-pool-azfunc
+      image: 1es-windows-2022
+      os: windows
+    sdl:
+      codeql:
+        runSourceLanguagesInSourceAnalysis: true
+
+    stages:
+      - stage: Build
+        dependsOn: []
+        jobs:
+          - job:
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  path: $(Build.ArtifactStagingDirectory)/dropOutput
+                  artifact: drop
+                  sbomBuildDropPath: '$(Build.ArtifactStagingDirectory)/dropInput'
+                  sbomPackageName: 'Azure Functions Node.js Worker'
+                  # The list of components can't be determined from the webpacked file in the staging dir, so reference the original node_modules folder
+                  sbomBuildComponentPath: '$(Build.SourcesDirectory)/node_modules'
+            steps:
+              - template: /azure-pipelines/templates/build.yml@self
+                parameters:
+                  IsPrerelease: ${{ parameters.IsPrerelease }}
+      - stage: PublishNuget
+        dependsOn: [Build]
+        jobs:
+          - template: /azure-pipelines/templates/worker.yml@self

--- a/azure-pipelines/worker-build.yml
+++ b/azure-pipelines/worker-build.yml
@@ -1,13 +1,7 @@
 parameters:
-  - name: IsPrerelease
-    type: boolean
-    default: true
-
-trigger:
-  batch: true
-  branches:
-    include:
-      - v3.x
+    - name: IsPrerelease
+      type: boolean
+      default: true
 
 pr: none
 
@@ -19,35 +13,35 @@ resources:
           ref: refs/tags/release
 
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1es
-  parameters:
-    pool:
-      name: 1es-pool-azfunc
-      image: 1es-windows-2022
-      os: windows
-    sdl:
-      codeql:
-        runSourceLanguagesInSourceAnalysis: true
+    template: v1/1ES.Official.PipelineTemplate.yml@1es
+    parameters:
+        pool:
+            name: 1es-pool-azfunc
+            image: 1es-windows-2022
+            os: windows
+        sdl:
+            codeql:
+                runSourceLanguagesInSourceAnalysis: true
 
-    stages:
-      - stage: Build
-        dependsOn: []
-        jobs:
-          - job:
-            templateContext:
-              outputs:
-                - output: pipelineArtifact
-                  path: $(Build.ArtifactStagingDirectory)/dropOutput
-                  artifact: drop
-                  sbomBuildDropPath: '$(Build.ArtifactStagingDirectory)/dropInput'
-                  sbomPackageName: 'Azure Functions Node.js Worker'
-                  # The list of components can't be determined from the webpacked file in the staging dir, so reference the original node_modules folder
-                  sbomBuildComponentPath: '$(Build.SourcesDirectory)/node_modules'
-            steps:
-              - template: /azure-pipelines/templates/build.yml@self
-                parameters:
-                  IsPrerelease: ${{ parameters.IsPrerelease }}
-      - stage: PublishNuget
-        dependsOn: [Build]
-        jobs:
-          - template: /azure-pipelines/templates/worker.yml@self
+        stages:
+            - stage: Build
+              dependsOn: []
+              jobs:
+                  - job:
+                    templateContext:
+                        outputs:
+                            - output: pipelineArtifact
+                              path: $(Build.ArtifactStagingDirectory)/dropOutput
+                              artifact: drop
+                              sbomBuildDropPath: '$(Build.ArtifactStagingDirectory)/dropInput'
+                              sbomPackageName: 'Azure Functions Node.js Worker'
+                              # The list of components can't be determined from the webpacked file in the staging dir, so reference the original node_modules folder
+                              sbomBuildComponentPath: '$(Build.SourcesDirectory)/node_modules'
+                    steps:
+                        - template: /azure-pipelines/templates/build.yml@self
+                          parameters:
+                              IsPrerelease: ${{ parameters.IsPrerelease }}
+            - stage: PublishNuget
+              dependsOn: [Build]
+              jobs:
+                  - template: /azure-pipelines/templates/worker.yml@self


### PR DESCRIPTION
Description 

Migrated worker release pipeline to 1ES. 

Key Information

1. Created a new build pipeline dedicated to worker release.
2. Tied the official build to release pipeline.
3. Publish package to nuget.

Proof
https://azfunc.visualstudio.com/internal/_build/results?buildId=206711&view=results
