### PR TITLE
Add end-of-life log for Node version

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,3 +2,21 @@
 // Licensed under the MIT License.
 
 export const version = '3.11.0';
+
+export const NODE_EOL_DATES: Record<string, string> = {
+    v14: '2023-04',
+    v16: '2024-09',
+    v18: '2025-04',
+    v20: '2026-04',
+    v22: '2027-04',
+    v24: '2028-04',
+};
+
+export const NODE_EOL_WARNING_DATES: Record<string, string> = {
+    v14: '2022-10',
+    v16: '2024-03',
+    v18: '2024-10',
+    v20: '2025-10',
+    v22: '2026-10',
+    v24: '2027-10',
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,9 +3,10 @@
 
 export const version = '3.11.0';
 
+// https://github.com/nodejs/Release
 export const NODE_EOL_DATES: Record<string, string> = {
     v14: '2023-04',
-    v16: '2024-09',
+    v16: '2023-09',
     v18: '2025-04',
     v20: '2026-04',
     v22: '2027-04',
@@ -14,7 +15,7 @@ export const NODE_EOL_DATES: Record<string, string> = {
 
 export const NODE_EOL_WARNING_DATES: Record<string, string> = {
     v14: '2022-10',
-    v16: '2024-03',
+    v16: '2023-03',
     v18: '2024-10',
     v20: '2025-10',
     v22: '2026-10',

--- a/src/nodejsWorker.ts
+++ b/src/nodejsWorker.ts
@@ -25,7 +25,7 @@ function validateNodeVersion(version: string) {
         const eolDateStr = NODE_EOL_DATES[major];
 
         if (!warningDateStr || !eolDateStr) {
-            const msg = `Unknown Node.js version: ${version}. Please change to a supported version: https://aka.ms/functions-node-versions`;
+            const msg = `Node.js version is not officially supported: ${version}. Please change to a supported version: https://aka.ms/functions-node-versions`;
             console.warn(warnPrefix + msg);
             return;
         }

--- a/src/nodejsWorker.ts
+++ b/src/nodejsWorker.ts
@@ -26,7 +26,7 @@ function validateNodeVersion(version: string) {
         const eolDateStr = NODE_EOL_DATES[major];
 
         if (!warningDateStr || !eolDateStr) {
-            const msg = `Node.js ${major} version is not officially supported. Please change to a supported version: ${upgradeUrl}`;
+            const msg = `Node.js ${major} is not officially supported. Please change to a supported version: ${upgradeUrl}`;
             console.warn(warnPrefix + msg);
         } else if (today >= eolDateStr) {
             const msg = `Node.js ${major} reached EOL on ${eolDateStr}. Please upgrade to a supported version: ${upgradeUrl}`;

--- a/src/nodejsWorker.ts
+++ b/src/nodejsWorker.ts
@@ -19,14 +19,13 @@ function currentYearMonth(): string {
 function validateNodeVersion(version: string) {
     try {
         const major = version.split('.')[0]; // e.g. "v18"
-        console.warn('Major: ' + major);
         const today = currentYearMonth();
 
         const warningDateStr = NODE_EOL_WARNING_DATES[major];
         const eolDateStr = NODE_EOL_DATES[major];
 
         if (!warningDateStr || !eolDateStr) {
-            const msg = `Unknown Node.js version: ${version}`;
+            const msg = `Unknown Node.js version: ${version}. Please change to a supported version: https://aka.ms/functions-node-versions`;
             console.warn(warnPrefix + msg);
             return;
         }

--- a/src/nodejsWorker.ts
+++ b/src/nodejsWorker.ts
@@ -1,53 +1,47 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
+import { NODE_EOL_DATES, NODE_EOL_WARNING_DATES } from './constants';
+
 const logPrefix = 'LanguageWorkerConsoleLog';
 const errorPrefix = logPrefix + '[error] ';
 const warnPrefix = logPrefix + '[warn] ';
-const supportedVersions: string[] = ['v14', 'v16', 'v18', 'v20', 'v22', 'v24'];
-const devOnlyVersions: string[] = ['v15', 'v17', 'v19', 'v21', 'v23'];
 let workerModule;
+
+function currentYearMonth(): string {
+    const now = new Date();
+    return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+}
 
 // Try validating node version
 // NOTE: This method should be manually tested if changed as it is in a sensitive code path
 //       and is JavaScript that runs on at least node version 0.10.28
 function validateNodeVersion(version: string) {
-    let errorMessage: string | undefined;
-    let warningMessage: string | undefined;
     try {
-        const versionSplit = version.split('.');
-        const major = versionSplit[0];
-        // process.version returns invalid output
-        if (versionSplit.length != 3) {
-            errorMessage = "Could not parse Node.js version: '" + version + "'";
-            // Unsupported version note: Documentation about Node's stable versions here: https://github.com/nodejs/Release#release-plan and an explanation here: https://medium.com/swlh/understanding-how-node-releases-work-in-2018-6fd356816db4
-        } else if (process.env.AZURE_FUNCTIONS_ENVIRONMENT == 'Development' && devOnlyVersions.indexOf(major) >= 0) {
-            warningMessage =
-                'Node.js version used (' +
-                version +
-                ') is not officially supported. You may use it during local development, but must use an officially supported version on Azure:' +
-                ' https://aka.ms/functions-node-versions';
-        } else if (supportedVersions.indexOf(major) < 0) {
-            errorMessage =
-                'Incompatible Node.js version' +
-                ' (' +
-                version +
-                ').' +
-                ' Refer to our documentation to see the Node.js versions supported by each version of Azure Functions: https://aka.ms/functions-node-versions';
+        const major = version.split('.')[0]; // e.g. "v18"
+        console.warn('Major: ' + major);
+        const today = currentYearMonth();
+
+        const warningDateStr = NODE_EOL_WARNING_DATES[major];
+        const eolDateStr = NODE_EOL_DATES[major];
+
+        if (!warningDateStr || !eolDateStr) {
+            const msg = `Unknown Node.js version: ${version}`;
+            console.warn(warnPrefix + msg);
+            return;
         }
-        // Unknown error
+
+        if (today >= eolDateStr) {
+            const msg = `Node.js ${major} reached EOL on ${eolDateStr}. Please upgrade to a supported version: https://aka.ms/functions-node-versions`;
+            console.error(errorPrefix + msg);
+        } else if (today >= warningDateStr) {
+            const msg = `Node.js ${major} will reach EOL on ${eolDateStr}. Consider upgrading: https://aka.ms/functions-node-versions`;
+            console.warn(warnPrefix + msg);
+        }
     } catch (err) {
-        const unknownError = 'Error in validating Node.js version. ';
+        const unknownError = 'Error validating Node.js version. ';
         console.error(errorPrefix + unknownError + err);
-        throw unknownError + err;
-    }
-    // Throw error for known version errors
-    if (errorMessage) {
-        console.error(errorPrefix + errorMessage);
-        throw new Error(errorMessage);
-    }
-    if (warningMessage) {
-        console.warn(warnPrefix + warningMessage);
+        throw err;
     }
 }
 

--- a/src/nodejsWorker.ts
+++ b/src/nodejsWorker.ts
@@ -6,6 +6,7 @@ import { NODE_EOL_DATES, NODE_EOL_WARNING_DATES } from './constants';
 const logPrefix = 'LanguageWorkerConsoleLog';
 const errorPrefix = logPrefix + '[error] ';
 const warnPrefix = logPrefix + '[warn] ';
+const upgradeUrl = 'https://aka.ms/functions-node-versions';
 let workerModule;
 
 function currentYearMonth(): string {
@@ -25,16 +26,13 @@ function validateNodeVersion(version: string) {
         const eolDateStr = NODE_EOL_DATES[major];
 
         if (!warningDateStr || !eolDateStr) {
-            const msg = `Node.js version is not officially supported: ${version}. Please change to a supported version: https://aka.ms/functions-node-versions`;
+            const msg = `Node.js ${major} version is not officially supported. Please change to a supported version: ${upgradeUrl}`;
             console.warn(warnPrefix + msg);
-            return;
-        }
-
-        if (today >= eolDateStr) {
-            const msg = `Node.js ${major} reached EOL on ${eolDateStr}. Please upgrade to a supported version: https://aka.ms/functions-node-versions`;
+        } else if (today >= eolDateStr) {
+            const msg = `Node.js ${major} reached EOL on ${eolDateStr}. Please upgrade to a supported version: ${upgradeUrl}`;
             console.error(errorPrefix + msg);
         } else if (today >= warningDateStr) {
-            const msg = `Node.js ${major} will reach EOL on ${eolDateStr}. Consider upgrading: https://aka.ms/functions-node-versions`;
+            const msg = `Node.js ${major} will reach EOL on ${eolDateStr}. Consider upgrading: ${upgradeUrl}`;
             console.warn(warnPrefix + msg);
         }
     } catch (err) {

--- a/src/nodejsWorker.ts
+++ b/src/nodejsWorker.ts
@@ -6,7 +6,7 @@ import { NODE_EOL_DATES, NODE_EOL_WARNING_DATES } from './constants';
 const logPrefix = 'LanguageWorkerConsoleLog';
 const errorPrefix = logPrefix + '[error] ';
 const warnPrefix = logPrefix + '[warn] ';
-const upgradeUrl = 'https://aka.ms/functions-node-versions';
+const upgradeUrl = 'https://aka.ms/functions-nodejs-supported-versions';
 let workerModule;
 
 function currentYearMonth(): string {
@@ -19,14 +19,17 @@ function currentYearMonth(): string {
 //       and is JavaScript that runs on at least node version 0.10.28
 function validateNodeVersion(version: string) {
     try {
-        const major = version.split('.')[0]; // e.g. "v18"
-        const today = currentYearMonth();
+        const versionSplit = version.split('.');
+        if (versionSplit.length != 3) {
+            throw new Error("Could not parse Node.js version: '" + version + "'");
+        }
 
+        const major = versionSplit[0]; // e.g. "v18"
         const warningDateStr = NODE_EOL_WARNING_DATES[major];
         const eolDateStr = NODE_EOL_DATES[major];
-
+        const today = currentYearMonth();
         if (!warningDateStr || !eolDateStr) {
-            const msg = `Node.js ${major} is not officially supported. Please change to a supported version: ${upgradeUrl}`;
+            const msg = `Incompatible Node.js version ${major}. Refer to our documentation to see the Node.js versions supported by each version of Azure Functions: ${upgradeUrl}`;
             console.warn(warnPrefix + msg);
         } else if (today >= eolDateStr) {
             const msg = `Node.js ${major} reached EOL on ${eolDateStr}. Please upgrade to a supported version: ${upgradeUrl}`;


### PR DESCRIPTION
<img width="1510" height="575" alt="image" src="https://github.com/user-attachments/assets/afdb1c9b-326d-4092-af15-f21443bf6090" />

<img width="1508" height="573" alt="image" src="https://github.com/user-attachments/assets/f1dca5ec-7ece-45b8-babe-440a08984218" />

<img width="1507" height="542" alt="image" src="https://github.com/user-attachments/assets/4acae9b1-be9b-4291-9d73-e6d0b54bb9cd" />

Node that Node 20's warning value was changed to test the warning case