### PR TITLE
Simplify Bootstrap entry for Host compatibility

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 export const version = '3.11.2';
-export const logPrefix = 'LanguageWorkerConsoleLog';
 export const upgradeUrl = 'https://aka.ms/functions-nodejs-supported-versions';
 
 // https://github.com/nodejs/Release

--- a/src/nodejsWorker.ts
+++ b/src/nodejsWorker.ts
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-import { logPrefix } from './constants';
+const logPrefix = 'LanguageWorkerConsoleLog';
 
 let workerModule;
 


### PR DESCRIPTION
Host would fail with the following: [Error] [Host.Function.Console] Error: Cannot find module './constants' 

Let's avoid a fragile dependency - keep nodeJsWorker simple as the entrypoint for the Host
