### PR TITLE
Add Node.js 26 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 |Branch|Status|[Runtime Version](https://docs.microsoft.com/azure/azure-functions/functions-versions)|Support level|Node.js Versions|
 |---|---|---|---|---|
-|v3.x (default)|[![Build Status](https://img.shields.io/azure-devops/build/azfunc/public/527/v3.x)](https://azfunc.visualstudio.com/public/_build/latest?definitionId=527&branchName=v3.x) [![Test Status](https://img.shields.io/azure-devops/tests/azfunc/public/527/v3.x?compact_message)](https://azfunc.visualstudio.com/public/_build/latest?definitionId=527&branchName=v3.x)|4|GA|20, 18|
+|v3.x (default)|[![Build Status](https://img.shields.io/azure-devops/build/azfunc/public/527/v3.x)](https://azfunc.visualstudio.com/public/_build/latest?definitionId=527&branchName=v3.x) [![Test Status](https://img.shields.io/azure-devops/tests/azfunc/public/527/v3.x?compact_message)](https://azfunc.visualstudio.com/public/_build/latest?definitionId=527&branchName=v3.x)|4|GA|26, 24, 22, 18|
 
 > NOTE: The branch corresponds to the _worker_ version, which is intentionally decoupled from the _runtime_ version.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 |Branch|Status|[Runtime Version](https://docs.microsoft.com/azure/azure-functions/functions-versions)|Support level|Node.js Versions|
 |---|---|---|---|---|
-|v3.x (default)|[![Build Status](https://img.shields.io/azure-devops/build/azfunc/public/527/v3.x)](https://azfunc.visualstudio.com/public/_build/latest?definitionId=527&branchName=v3.x) [![Test Status](https://img.shields.io/azure-devops/tests/azfunc/public/527/v3.x?compact_message)](https://azfunc.visualstudio.com/public/_build/latest?definitionId=527&branchName=v3.x)|4|GA|26, 24, 22, 18|
+|v3.x (default)|[![Build Status](https://img.shields.io/azure-devops/build/azfunc/public/527/v3.x)](https://azfunc.visualstudio.com/public/_build/latest?definitionId=527&branchName=v3.x) [![Test Status](https://img.shields.io/azure-devops/tests/azfunc/public/527/v3.x?compact_message)](https://azfunc.visualstudio.com/public/_build/latest?definitionId=527&branchName=v3.x)|4|GA|26, 24, 22|
 
 > NOTE: The branch corresponds to the _worker_ version, which is intentionally decoupled from the _runtime_ version.
 

--- a/Worker.nuspec
+++ b/Worker.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Microsoft.Azure.Functions.NodeJsWorker</id>
-    <version>3.13.0</version>
+    <version>3.14.0</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/azure-pipelines/templates/test.yml
+++ b/azure-pipelines/templates/test.yml
@@ -9,12 +9,12 @@ jobs:
                   NODE_VERSION: '16.x'
               Node18:
                   NODE_VERSION: '18.x'
-              Node20:
-                  NODE_VERSION: '20.x'
               Node22:
                   NODE_VERSION: '22.x'
               Node24:
                   NODE_VERSION: '24.x'
+              Node26:
+                  NODE_VERSION: '26.x'
 
       steps:
           - task: NodeTool@0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-functions-nodejs-worker",
-    "version": "3.13.0",
+    "version": "3.14.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-functions-nodejs-worker",
-            "version": "3.13.0",
+            "version": "3.14.0",
             "license": "(MIT OR Apache-2.0)",
             "dependencies": {
                 "@azure/functions": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-functions-nodejs-worker",
     "author": "Microsoft Corporation",
-    "version": "3.13.0",
+    "version": "3.14.0",
     "description": "Microsoft Azure Functions NodeJS Worker",
     "license": "(MIT OR Apache-2.0)",
     "dependencies": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-export const version = '3.13.0';
+export const version = '3.14.0';
 export const upgradeUrl = 'https://aka.ms/functions-nodejs-supported-versions';
 
 // https://github.com/nodejs/Release
@@ -12,6 +12,7 @@ export const NODE_EOL_DATES: Record<string, string> = {
     v20: '2026-04',
     v22: '2027-04',
     v24: '2028-04',
+    v26: '2029-04',
 };
 
 export const NODE_EOL_WARNING_DATES: Record<string, string> = {
@@ -21,4 +22,5 @@ export const NODE_EOL_WARNING_DATES: Record<string, string> = {
     v20: '2025-10',
     v22: '2026-10',
     v24: '2027-10',
+    v26: '2028-10',
 };

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'mocha';
+import { expect } from 'chai';
+import { getNodeVersionLog } from '../src/utils/util';
+
+describe('utils', () => {
+    describe('getNodeVersionLog', () => {
+        it('recognizes Node.js v26 as a known version', () => {
+            const result = getNodeVersionLog('v26.0.0');
+
+            expect(result?.message ?? '').to.not.contain('Incompatible Node.js version v26');
+        });
+
+        it('warns for unknown Node.js versions', () => {
+            const result = getNodeVersionLog('v27.0.0');
+
+            expect(result?.message).to.contain('Incompatible Node.js version v27');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Add Node.js 26 to the worker's version metadata, CI test matrix, package version, README support table, and version-support tests.

## Changes

- Bump the worker package version from `3.13.0` to `3.14.0` in `Worker.nuspec`, `package.json`, `package-lock.json`, and `src/constants.ts`
- Add `v26` to `NODE_EOL_DATES` (`2029-04`) and `NODE_EOL_WARNING_DATES` (`2028-10`) in `src/constants.ts`
  - Dates from the official Node.js release schedule: https://github.com/nodejs/Release
  - Node 26 start: 2026-05-05, LTS: 2026-10-28, Maintenance: 2027-10-20, EOL: 2029-04-30
- Add `Node26: NODE_VERSION: '26.x'` to the CI test matrix in `azure-pipelines/templates/test.yml`
- Remove `Node20` from the CI test matrix because Node 20 reached EOL in April 2026
- Update the README support table to include `26, 24, 22`
- Add a focused unit test that verifies Node.js v26 is recognized as a known version and an unknown future version is treated as incompatible

## Context

This is part of the Node.js 26 runtime release for Azure Functions. The Docker image PR is already open in AAPT-Antares-Functions-Docker (ADO PR #15681135).

Prior art for Node 24:
- Worker support: https://github.com/Azure/azure-functions-nodejs-worker/pull/768
- Strip-only mode fix: https://github.com/Azure/azure-functions-nodejs-worker/pull/770
- Host consuming worker 3.11.0: https://github.com/Azure/azure-functions-host/pull/11251

## Testing

- `git diff --check`
- `npm run lint`
- `npm test` (134 passing, 8 pending)
- Re-ran the Release Process command: `npm run updateVersion -- --version 3.14.0`
  - Result: no additional diff; it updates `package.json`, `package-lock.json`, `Worker.nuspec`, and `src/constants.ts`, which are already updated in this PR.