### PR TITLE
Bump Node.js worker to 3.14.1

### DIFF
--- a/Worker.nuspec
+++ b/Worker.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Microsoft.Azure.Functions.NodeJsWorker</id>
-    <version>3.14.0</version>
+    <version>3.14.1</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-functions-nodejs-worker",
-    "version": "3.14.0",
+    "version": "3.14.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-functions-nodejs-worker",
-            "version": "3.14.0",
+            "version": "3.14.1",
             "license": "(MIT OR Apache-2.0)",
             "dependencies": {
                 "@azure/functions": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-functions-nodejs-worker",
     "author": "Microsoft Corporation",
-    "version": "3.14.0",
+    "version": "3.14.1",
     "description": "Microsoft Azure Functions NodeJS Worker",
     "license": "(MIT OR Apache-2.0)",
     "dependencies": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-export const version = '3.14.0';
+export const version = '3.14.1';
 export const upgradeUrl = 'https://aka.ms/functions-nodejs-supported-versions';
 
 // https://github.com/nodejs/Release


### PR DESCRIPTION
## Summary

Bump the Node.js worker package version from `3.14.0` to `3.14.1` for a patch release that includes the bundled protobuf inquire fix from PR #815.

## Context

`v3.14.0` included the Node.js 26 support work but the packaged `worker-bundle.js` could fail Host startup after the protobufjs security update. PR #815 fixed the bundle behavior by adding a webpack-scoped shim for `@protobufjs/inquire` while keeping the production dependency tree current.

This PR prepares the patch version to release that fix as `Microsoft.Azure.Functions.NodeJsWorker` `3.14.1`.

Related:
- Fix PR: https://github.com/Azure/azure-functions-nodejs-worker/pull/815
- Follow-up issue for removing the shim after upstream fix: https://github.com/Azure/azure-functions-nodejs-worker/issues/816
- Upstream protobufjs issue: https://github.com/protobufjs/protobuf.js/issues/2214

## Changes

- Update `package.json` from `3.14.0` to `3.14.1`.
- Update `package-lock.json` root package version to `3.14.1`.
- Update `Worker.nuspec` to `3.14.1`.
- Update `src/constants.ts` worker version to `3.14.1`.

## Validation

- `npx ts-node ./scripts/updateVersion.ts --validate`
- `npm ci`
- `npm run build`
- `npm run webpack`
- `node .\scripts\hostSanityTest.js --host-repo C:\dobby\kafka\repos\azure-functions-host --timeout-seconds 180 --port 7094`
  - HTTP 200
  - Response: `Hello, SanityTest. Node v22.17.0`
- `npm audit --omit=dev` — 0 vulnerabilities
- `npm run lint`
- `npm test` — 134 passing
- `git -c core.whitespace=cr-at-eol diff --check -- Worker.nuspec package-lock.json package.json src/constants.ts`