### PR TITLE
Trigger code mirror on release tags

### DIFF
--- a/azure-pipelines/code-mirror.yml
+++ b/azure-pipelines/code-mirror.yml
@@ -2,6 +2,9 @@ trigger:
     branches:
         include:
             - v*.x
+    tags:
+        include:
+            - v*.*.*
 
 resources:
     repositories:


### PR DESCRIPTION
## Summary

Update the code mirror pipeline trigger so release tag pushes also run the mirror path.

## Problem

The current mirror pipeline only triggers on version branch updates:

```yaml
trigger:
    branches:
        include:
            - v*.x
```

In the Node.js worker release flow, the version bump PR is merged first, then a release tag such as `v3.14.1` is created afterward. The branch merge triggers the mirror, but the later tag push does not. As a result, the public GitHub tag can exist while the internal mirror used by the official build tag picker does not have the tag yet.

## Changes

Add a tag trigger for release-version tags:

```yaml
trigger:
    branches:
        include:
            - v*.x
    tags:
        include:
            - v*.*.*
```

## Safety

- This only starts the code mirror pipeline for release-style tags.
- It does not automatically publish NuGet packages or run the Worker release pipeline.
- The official build remains manual and still requires selecting the tag and `IsPrerelease` settings.
- This keeps branch mirroring behavior unchanged.

## Validation

- `git diff --check -- azure-pipelines/code-mirror.yml`