### PR TITLE
Sanitize serialized worker errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
                 "mocha-multi-reporters": "^1.5.1",
                 "mock-fs": "^5.1.2",
                 "prettier": "^2.4.1",
-                "protobufjs": "^7.5.5",
+                "protobufjs": "^7.6.0",
                 "protobufjs-cli": "^1.2.1",
                 "rimraf": "^2.6.3",
                 "semver": "^7.3.5",
@@ -496,7 +496,8 @@
         "node_modules/@protobufjs/aspromise": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-            "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+            "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/base64": {
             "version": "1.1.2",
@@ -515,19 +516,13 @@
             "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
         },
         "node_modules/@protobufjs/fetch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+            "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "@protobufjs/aspromise": "^1.1.1",
-                "@protobufjs/inquire": "^1.1.0"
+                "@protobufjs/aspromise": "^1.1.1"
             }
-        },
-        "node_modules/@protobufjs/fetch/node_modules/@protobufjs/inquire": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-            "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/float": {
             "version": "1.0.2",
@@ -4808,9 +4803,9 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.5.6",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-            "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
+            "integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -4818,14 +4813,14 @@
                 "@protobufjs/base64": "^1.1.2",
                 "@protobufjs/codegen": "^2.0.5",
                 "@protobufjs/eventemitter": "^1.1.0",
-                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/fetch": "^1.1.1",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.1",
+                "@protobufjs/inquire": "^1.1.2",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
                 "@protobufjs/utf8": "^1.1.1",
                 "@types/node": ">=13.7.0",
-                "long": "^5.0.0"
+                "long": "^5.3.2"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -4945,9 +4940,10 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/protobufjs/node_modules/long": {
-            "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-            "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+            "license": "Apache-2.0"
         },
         "node_modules/punycode": {
             "version": "2.1.1",
@@ -6856,19 +6852,11 @@
             "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
         },
         "@protobufjs/fetch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+            "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
             "requires": {
-                "@protobufjs/aspromise": "^1.1.1",
-                "@protobufjs/inquire": "1.1.0"
-            },
-            "dependencies": {
-                "@protobufjs/inquire": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-                    "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
-                }
+                "@protobufjs/aspromise": "^1.1.1"
             }
         },
         "@protobufjs/float": {
@@ -10034,22 +10022,22 @@
             "dev": true
         },
         "protobufjs": {
-            "version": "7.5.6",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-            "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
+            "integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
             "requires": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
                 "@protobufjs/codegen": "^2.0.5",
                 "@protobufjs/eventemitter": "^1.1.0",
-                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/fetch": "^1.1.1",
                 "@protobufjs/float": "^1.0.2",
                 "@protobufjs/inquire": "1.1.0",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
                 "@protobufjs/utf8": "^1.1.1",
                 "@types/node": ">=13.7.0",
-                "long": "^5.0.0"
+                "long": "^5.3.2"
             },
             "dependencies": {
                 "@protobufjs/inquire": {
@@ -10058,9 +10046,9 @@
                     "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
                 },
                 "long": {
-                    "version": "5.2.3",
-                    "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-                    "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+                    "version": "5.3.2",
+                    "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+                    "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "mocha-multi-reporters": "^1.5.1",
         "mock-fs": "^5.1.2",
         "prettier": "^2.4.1",
-        "protobufjs": "^7.5.5",
+        "protobufjs": "^7.6.0",
         "protobufjs-cli": "^1.2.1",
         "rimraf": "^2.6.3",
         "semver": "^7.3.5",

--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -7,6 +7,7 @@ import { CreateGrpcEventStream, getConnectionUri } from './GrpcClient';
 import { setupCoreModule } from './setupCoreModule';
 import { setupEventStream } from './setupEventStream';
 import { startBlockedMonitor } from './utils/blockedMonitor';
+import { sanitizeErrorString } from './utils/errorSanitizer';
 import { systemError, systemLog } from './utils/Logger';
 import { isEnvironmentVariableSet } from './utils/util';
 import { worker } from './WorkerContext';
@@ -41,7 +42,7 @@ export function startNodeWorker(args) {
     } catch (err) {
         const error = ensureErrorType(err);
         error.isAzureFunctionsSystemError = true;
-        const message = 'Error creating GRPC event stream: ' + error.message;
+        const message = 'Error creating GRPC event stream: ' + sanitizeErrorString(error.message);
         trySetErrorMessage(error, message);
         throw error;
     }
@@ -60,11 +61,11 @@ export function startNodeWorker(args) {
         const error = ensureErrorType(err);
         let errorMessage: string;
         if (error.isAzureFunctionsSystemError) {
-            errorMessage = `Worker uncaught exception: ${error.stack || err}`;
+            errorMessage = `Worker uncaught exception: ${sanitizeErrorString(error.stack || String(err))}`;
         } else {
-            errorMessage = `Worker uncaught exception (learn more: https://go.microsoft.com/fwlink/?linkid=2097909 ): ${
-                error.stack || err
-            }`;
+            errorMessage = `Worker uncaught exception (learn more: https://go.microsoft.com/fwlink/?linkid=2097909 ): ${sanitizeErrorString(
+                error.stack || String(err)
+            )}`;
         }
 
         systemError(errorMessage);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -36,6 +36,29 @@ export class ReadOnlyError extends AzFuncTypeError {
     }
 }
 
+const hiddenCredential = '[Hidden Credential]';
+const circularReference = '[Circular]';
+const credentialNameFragments = ['password', 'pwd', 'key', 'secret', 'token', 'sas'];
+const credentialTokens = [
+    'Token=',
+    'DefaultEndpointsProtocol=http',
+    'AccountKey=',
+    'Data Source=',
+    'Server=',
+    'Password=',
+    'pwd=',
+    '&amp;sig=',
+    '&sig=',
+    '?sig=',
+    'SharedAccessKey=',
+    '&amp;code=',
+    '&code=',
+    '?code=',
+    '/code=',
+    'key=',
+];
+const urlCredentialPattern = /\b([a-zA-Z]+):\/\/([^:/\s]+):([^@/\s]+)@([^:/\s]+):([0-9]+)\b/g;
+
 export function ensureErrorType(err: unknown): ValidatedError {
     if (err instanceof Error) {
         return err;
@@ -44,14 +67,82 @@ export function ensureErrorType(err: unknown): ValidatedError {
         if (err === undefined || err === null) {
             message = 'Unknown error';
         } else if (typeof err === 'string') {
-            message = err;
+            message = sanitizeErrorString(err);
         } else if (typeof err === 'object') {
-            message = JSON.stringify(err);
+            message = safeStringify(err);
         } else {
-            message = String(err);
+            message = sanitizeErrorString(String(err));
         }
         return new Error(message);
     }
+}
+
+export function sanitizeErrorString(input: string): string {
+    if (!input) {
+        return input;
+    }
+
+    let sanitized = input;
+    for (const token of credentialTokens) {
+        sanitized = replaceCredentialToken(sanitized, token);
+    }
+
+    return sanitized.replace(urlCredentialPattern, hiddenCredential);
+}
+
+function replaceCredentialToken(input: string, token: string): string {
+    const lowerInput = input.toLowerCase();
+    const lowerToken = token.toLowerCase();
+    let startIndex = lowerInput.indexOf(lowerToken);
+    if (startIndex === -1) {
+        return input;
+    }
+
+    let sanitized = '';
+    let searchOffset = 0;
+    while (startIndex !== -1) {
+        const credentialEnd = findCredentialEnd(input, startIndex);
+        sanitized += input.substring(searchOffset, startIndex) + hiddenCredential;
+        searchOffset = credentialEnd;
+        startIndex = lowerInput.indexOf(lowerToken, searchOffset);
+    }
+
+    return sanitized + input.substring(searchOffset);
+}
+
+function findCredentialEnd(input: string, startIndex: number): number {
+    const terminatorIndex = input.substring(startIndex).search(/[<"'\r\n]/);
+    return terminatorIndex === -1 ? input.length : startIndex + terminatorIndex;
+}
+
+function safeStringify(value: object): string {
+    const seen = new WeakSet<object>();
+    return JSON.stringify(value, (key, val: unknown) => {
+        if (isCredentialName(key)) {
+            return hiddenCredential;
+        }
+
+        if (typeof val === 'string') {
+            return sanitizeErrorString(val);
+        }
+
+        if (typeof val === 'bigint') {
+            return val.toString();
+        }
+
+        if (typeof val === 'object' && val !== null) {
+            if (seen.has(val)) {
+                return circularReference;
+            }
+            seen.add(val);
+        }
+
+        return val;
+    });
+}
+
+function isCredentialName(name: string): boolean {
+    return credentialNameFragments.some((fragment) => name.toLowerCase().includes(fragment));
 }
 
 export function trySetErrorMessage(err: Error, message: string): void {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
+import { sanitizeErrorString, stringifySanitizedErrorObject } from './utils/errorSanitizer';
+
 export interface AzFuncError {
     /**
      * System errors can be tracked in our telemetry
@@ -36,29 +38,6 @@ export class ReadOnlyError extends AzFuncTypeError {
     }
 }
 
-const hiddenCredential = '[Hidden Credential]';
-const circularReference = '[Circular]';
-const credentialNameFragments = ['password', 'pwd', 'key', 'secret', 'token', 'sas'];
-const credentialTokens = [
-    'Token=',
-    'DefaultEndpointsProtocol=http',
-    'AccountKey=',
-    'Data Source=',
-    'Server=',
-    'Password=',
-    'pwd=',
-    '&amp;sig=',
-    '&sig=',
-    '?sig=',
-    'SharedAccessKey=',
-    '&amp;code=',
-    '&code=',
-    '?code=',
-    '/code=',
-    'key=',
-];
-const urlCredentialPattern = /\b([a-zA-Z]+):\/\/([^:/\s]+):([^@/\s]+)@([^:/\s]+):([0-9]+)\b/g;
-
 export function ensureErrorType(err: unknown): ValidatedError {
     if (err instanceof Error) {
         return err;
@@ -69,7 +48,7 @@ export function ensureErrorType(err: unknown): ValidatedError {
         } else if (typeof err === 'string') {
             message = sanitizeErrorString(err);
         } else if (typeof err === 'object') {
-            message = safeStringify(err);
+            message = stringifySanitizedErrorObject(err);
         } else {
             message = sanitizeErrorString(String(err));
         }
@@ -77,77 +56,9 @@ export function ensureErrorType(err: unknown): ValidatedError {
     }
 }
 
-export function sanitizeErrorString(input: string): string {
-    if (!input) {
-        return input;
-    }
-
-    let sanitized = input;
-    for (const token of credentialTokens) {
-        sanitized = replaceCredentialToken(sanitized, token);
-    }
-
-    return sanitized.replace(urlCredentialPattern, hiddenCredential);
-}
-
-function replaceCredentialToken(input: string, token: string): string {
-    const lowerInput = input.toLowerCase();
-    const lowerToken = token.toLowerCase();
-    let startIndex = lowerInput.indexOf(lowerToken);
-    if (startIndex === -1) {
-        return input;
-    }
-
-    let sanitized = '';
-    let searchOffset = 0;
-    while (startIndex !== -1) {
-        const credentialEnd = findCredentialEnd(input, startIndex);
-        sanitized += input.substring(searchOffset, startIndex) + hiddenCredential;
-        searchOffset = credentialEnd;
-        startIndex = lowerInput.indexOf(lowerToken, searchOffset);
-    }
-
-    return sanitized + input.substring(searchOffset);
-}
-
-function findCredentialEnd(input: string, startIndex: number): number {
-    const terminatorIndex = input.substring(startIndex).search(/[<"'\r\n]/);
-    return terminatorIndex === -1 ? input.length : startIndex + terminatorIndex;
-}
-
-function safeStringify(value: object): string {
-    const seen = new WeakSet<object>();
-    return JSON.stringify(value, (key, val: unknown) => {
-        if (isCredentialName(key)) {
-            return hiddenCredential;
-        }
-
-        if (typeof val === 'string') {
-            return sanitizeErrorString(val);
-        }
-
-        if (typeof val === 'bigint') {
-            return val.toString();
-        }
-
-        if (typeof val === 'object' && val !== null) {
-            if (seen.has(val)) {
-                return circularReference;
-            }
-            seen.add(val);
-        }
-
-        return val;
-    });
-}
-
-function isCredentialName(name: string): boolean {
-    return credentialNameFragments.some((fragment) => name.toLowerCase().includes(fragment));
-}
-
 export function trySetErrorMessage(err: Error, message: string): void {
     try {
-        err.message = message;
+        err.message = sanitizeErrorString(message);
     } catch {
         // If we can't set the message, we'll keep the error as is
     }

--- a/src/setupEventStream.ts
+++ b/src/setupEventStream.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
-import { AzFuncSystemError, ensureErrorType } from './errors';
+import { AzFuncSystemError, ensureErrorType, sanitizeErrorString } from './errors';
 import { EventHandler, SupportedRequest } from './eventHandlers/EventHandler';
 import { FunctionEnvironmentReloadHandler } from './eventHandlers/FunctionEnvironmentReloadHandler';
 import { FunctionLoadHandler } from './eventHandlers/FunctionLoadHandler';
@@ -98,7 +98,7 @@ async function handleMessage(inMsg: rpc.StreamingMessage): Promise<void> {
         const error = ensureErrorType(err);
         if (error.isAzureFunctionsSystemError && !error.loggedOverRpc) {
             worker.log({
-                message: error.message,
+                message: sanitizeErrorString(error.message),
                 level: rpc.RpcLog.Level.Error,
                 logCategory: rpc.RpcLog.RpcLogCategory.System,
             });
@@ -109,8 +109,8 @@ async function handleMessage(inMsg: rpc.StreamingMessage): Promise<void> {
             response.result = {
                 status: rpc.StatusResult.Status.Failure,
                 exception: {
-                    message: error.message,
-                    stackTrace: error.stack,
+                    message: sanitizeErrorString(error.message),
+                    stackTrace: error.stack ? sanitizeErrorString(error.stack) : error.stack,
                 },
             };
             outMsg[eventHandler.responseName] = response;

--- a/src/setupEventStream.ts
+++ b/src/setupEventStream.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
-import { AzFuncSystemError, ensureErrorType, sanitizeErrorString } from './errors';
+import { AzFuncSystemError, ensureErrorType } from './errors';
 import { EventHandler, SupportedRequest } from './eventHandlers/EventHandler';
 import { FunctionEnvironmentReloadHandler } from './eventHandlers/FunctionEnvironmentReloadHandler';
 import { FunctionLoadHandler } from './eventHandlers/FunctionLoadHandler';
@@ -10,6 +10,7 @@ import { FunctionsMetadataHandler } from './eventHandlers/FunctionsMetadataHandl
 import { InvocationHandler } from './eventHandlers/InvocationHandler';
 import { terminateWorker } from './eventHandlers/terminateWorker';
 import { WorkerInitHandler } from './eventHandlers/WorkerInitHandler';
+import { sanitizeErrorString } from './utils/errorSanitizer';
 import { systemError } from './utils/Logger';
 import { nonNullProp } from './utils/nonNull';
 import { worker } from './WorkerContext';

--- a/src/utils/errorSanitizer.ts
+++ b/src/utils/errorSanitizer.ts
@@ -1,0 +1,93 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+const hiddenCredential = '[Hidden Credential]';
+const circularReference = '[Circular]';
+const credentialNameFragments = ['password', 'pwd', 'key', 'secret', 'token', 'sas'];
+const credentialTokens = [
+    'Token=',
+    'DefaultEndpointsProtocol=http',
+    'AccountKey=',
+    'Data Source=',
+    'Server=',
+    'Password=',
+    'pwd=',
+    '&amp;sig=',
+    '&sig=',
+    '?sig=',
+    'SharedAccessKey=',
+    '&amp;code=',
+    '&code=',
+    '?code=',
+    '/code=',
+    'key=',
+];
+const urlCredentialPattern = /\b([a-zA-Z]+):\/\/([^:/\s]+):([^@/\s]+)@([^:/\s]+):([0-9]+)\b/g;
+
+export function sanitizeErrorString(input: string): string {
+    if (!input) {
+        return input;
+    }
+
+    let sanitized = input;
+    for (const token of credentialTokens) {
+        sanitized = replaceCredentialToken(sanitized, token);
+    }
+
+    return sanitized.replace(urlCredentialPattern, hiddenCredential);
+}
+
+export function stringifySanitizedErrorObject(value: object): string {
+    const seen = new WeakSet<object>();
+    return JSON.stringify(value, (key, val: unknown) => {
+        if (isCredentialName(key)) {
+            return hiddenCredential;
+        }
+
+        if (typeof val === 'string') {
+            return sanitizeErrorString(val);
+        }
+
+        if (typeof val === 'bigint') {
+            return val.toString();
+        }
+
+        if (typeof val === 'object' && val !== null) {
+            if (seen.has(val)) {
+                return circularReference;
+            }
+            seen.add(val);
+        }
+
+        return val;
+    });
+}
+
+function replaceCredentialToken(input: string, token: string): string {
+    const lowerInput = input.toLowerCase();
+    const lowerToken = token.toLowerCase();
+    let startIndex = lowerInput.indexOf(lowerToken);
+    if (startIndex === -1) {
+        return input;
+    }
+
+    let sanitized = '';
+    let searchOffset = 0;
+    while (startIndex !== -1) {
+        const credentialEnd = findCredentialEnd(input, startIndex);
+        sanitized += input.substring(searchOffset, startIndex) + hiddenCredential;
+        searchOffset = credentialEnd;
+        startIndex = lowerInput.indexOf(lowerToken, searchOffset);
+    }
+
+    return sanitized + input.substring(searchOffset);
+}
+
+function findCredentialEnd(input: string, startIndex: number): number {
+    const terminatorIndex = input.substring(startIndex).search(/[<"'\r\n]/);
+    return terminatorIndex === -1 ? input.length : startIndex + terminatorIndex;
+}
+
+function isCredentialName(name: string): boolean {
+    return credentialNameFragments.some((fragment) => name.toLowerCase().includes(fragment));
+}

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -3,7 +3,8 @@
 
 import 'mocha';
 import { expect } from 'chai';
-import { ensureErrorType, sanitizeErrorString, trySetErrorMessage } from '../src/errors';
+import { ensureErrorType, trySetErrorMessage } from '../src/errors';
+import { sanitizeErrorString } from '../src/utils/errorSanitizer';
 
 describe('errors', () => {
     it('null', () => {
@@ -88,6 +89,13 @@ describe('errors', () => {
         trySetErrorMessage(actualError, 'modified message');
 
         expect(actualError.message).to.equal('modified message');
+    });
+
+    it('sanitizes modified error message', () => {
+        const actualError = new Error('test2');
+        trySetErrorMessage(actualError, 'AccountKey=abc123');
+
+        expect(actualError.message).to.equal('[Hidden Credential]');
     });
 
     it('readonly error', () => {

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -3,7 +3,7 @@
 
 import 'mocha';
 import { expect } from 'chai';
-import { ensureErrorType, trySetErrorMessage } from '../src/errors';
+import { ensureErrorType, sanitizeErrorString, trySetErrorMessage } from '../src/errors';
 
 describe('errors', () => {
     it('null', () => {
@@ -29,8 +29,49 @@ describe('errors', () => {
         validateError(ensureErrorType(''), '');
     });
 
+    it('string with credential token', () => {
+        validateError(ensureErrorType('AccountKey=abc123;EndpointSuffix=core.windows.net'), '[Hidden Credential]');
+    });
+
+    it('sanitizes url credentials', () => {
+        expect(sanitizeErrorString('failed to connect to https://user:pass@example.com:443')).to.equal(
+            'failed to connect to [Hidden Credential]'
+        );
+    });
+
+    it('preserves stack text after credential tokens', () => {
+        expect(sanitizeErrorString('failed AccountKey=abc123\n    at invokeFunction')).to.equal(
+            'failed [Hidden Credential]\n    at invokeFunction'
+        );
+    });
+
     it('object', () => {
         validateError(ensureErrorType({ test: '2' }), '{"test":"2"}');
+    });
+
+    it('object with credential properties', () => {
+        validateError(
+            ensureErrorType({
+                message: 'Auth failed',
+                secretKey: 'secret-value',
+                nested: { password: 'password-value', visible: 'safe' },
+            }),
+            '{"message":"Auth failed","secretKey":"[Hidden Credential]","nested":{"password":"[Hidden Credential]","visible":"safe"}}'
+        );
+    });
+
+    it('object with credential tokens in string values', () => {
+        validateError(
+            ensureErrorType({ connectionString: 'AccountKey=abc123;EndpointSuffix=core.windows.net' }),
+            '{"connectionString":"[Hidden Credential]"}'
+        );
+    });
+
+    it('object with circular reference', () => {
+        const err: Record<string, unknown> = { message: 'failed' };
+        err.self = err;
+
+        validateError(ensureErrorType(err), '{"message":"failed","self":"[Circular]"}');
     });
 
     it('array', () => {


### PR DESCRIPTION
## Summary
- add credential-aware sanitization when serializing non-Error thrown values
- redact credential-like property names and known credential tokens while preserving useful object context
- sanitize worker exception messages and stack traces before sending invocation failures to the host
- handle circular references in thrown objects without throwing during error conversion

## Notes
This is a first implementation intended to support review and discussion. The sanitizer follows the same broad approach as azure-functions-host by redacting obvious credential names/tokens, while preserving non-secret diagnostic context.

Related library PR will apply the same serialization behavior in `@azure/functions`.

## Validation
- `npm test` (148 passing, 8 pending)
- `npm run lint`
