### PR TITLE
Handle prerelease Node.js versions without failing worker initialization

### DIFF
--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -25,12 +25,19 @@ interface NodeVersionLog {
 }
 
 export function getNodeVersionLog(version: string): NodeVersionLog | undefined {
-    const versionSplit = version.split('.');
-    if (versionSplit.length != 3) {
+    const parsedVersion = semver.parse(version);
+    if (!parsedVersion) {
         throw new Error("Could not parse Node.js version: '" + version + "'");
     }
 
-    const major = versionSplit[0]; // e.g. "v18"
+    const major = `v${parsedVersion.major}`;
+    if (parsedVersion.prerelease.length > 0) {
+        return {
+            message: `Prerelease Node.js version ${version} is not supported. Use a stable Node.js version: ${upgradeUrl}`,
+            level: rpc.RpcLog.Level.Warning,
+        };
+    }
+
     const warningDateStr = NODE_EOL_WARNING_DATES[major];
     const eolDateStr = NODE_EOL_DATES[major];
     const today = currentYearMonth();

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -3,6 +3,7 @@
 
 import 'mocha';
 import { expect } from 'chai';
+import { AzureFunctionsRpcMessages as rpc } from '../azure-functions-language-worker-protobuf/src/rpc';
 import { getNodeVersionLog } from '../src/utils/util';
 
 describe('utils', () => {
@@ -11,6 +12,19 @@ describe('utils', () => {
             const result = getNodeVersionLog('v26.0.0');
 
             expect(result?.message ?? '').to.not.contain('Incompatible Node.js version v26');
+        });
+
+        it('warns for prerelease Node.js versions', () => {
+            const result = getNodeVersionLog('v26.8.0-alpha.0.0.0');
+
+            expect(result?.message).to.contain('Prerelease Node.js version v26.8.0-alpha.0.0.0');
+            expect(result?.level).to.equal(rpc.RpcLog.Level.Warning);
+        });
+
+        it('rejects invalid Node.js versions', () => {
+            expect(() => getNodeVersionLog('not-a-version')).to.throw(
+                "Could not parse Node.js version: 'not-a-version'"
+            );
         });
 
         it('warns for unknown Node.js versions', () => {


### PR DESCRIPTION
## Summary

- parse Node.js runtime versions with the existing `semver` dependency
- warn for valid prerelease versions instead of failing worker initialization
- preserve the parse error for invalid version strings

Fixes #842.

## Why

The worker's version check split `process.version` on `.` and required exactly three components. A valid prerelease such as `v26.8.0-alpha.0.0.0` therefore caused `WorkerInitRequest` to fail before the worker could start.

This behavior was exposed by the Azure Functions Docker hotfix PR:
https://dev.azure.com/msazure/One/_git/AAPT-Antares-Functions-Docker/pullrequest/16949790

The root problem is not in the worker: NodeSource package `26.8.0-1nodesource1` appeared to be a stable package version, but its installed Node binary reported `v26.8.0-alpha.0.0.0`. Production images expecting stable Node.js must still reject that artifact. This worker change is defense in depth so diagnostic version validation does not make the language worker unavailable for a syntactically valid prerelease version.

## Tests

Red before the implementation:

```text
Error: Could not parse Node.js version: 'v26.8.0-alpha.0.0.0'
```

Validated with fnm Node.js `v22.22.3`:

- `npm run build`
- `npm run lint`
- focused `getNodeVersionLog` tests: 4 passing
- full suite: 147 passing, 8 pending, 3 unrelated timing failures
- the 3 failed existing cases passed when rerun alone
